### PR TITLE
feat: improve about me section typography

### DIFF
--- a/src/components/AboutMe/DeveloperIntro.tsx
+++ b/src/components/AboutMe/DeveloperIntro.tsx
@@ -67,7 +67,7 @@ export const DeveloperIntro: React.FC = () => {
 
           {/* 텍스트 */}
           <motion.div>
-            <p className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-[100%] font-bold text-2xl sm:text-3xl lg:text-4xl mt-4 tracking-wide lg:tracking-wider whitespace-nowrap"> {t('developerIntro')} </p>
+            <p className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-[100%] font-black text-2xl sm:text-3xl lg:text-4xl mt-4 tracking-tight whitespace-nowrap"> {t('developerIntro')} </p>
           </motion.div>
         </div>
       </div>

--- a/src/components/AboutMe/IntroLine.tsx
+++ b/src/components/AboutMe/IntroLine.tsx
@@ -84,10 +84,10 @@ export const IntroLine: React.FC = () => {
             style={{ opacity: startContentOpacity }}
             className={`absolute inset-0 z-0`}
           >
-            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-[100%] text-center text-lg sm:text-2xl lg:text-3xl text-white leading-relaxed tracking-wide lg:tracking-wider whitespace-nowrap">
+            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-[100%] text-center text-lg sm:text-2xl lg:text-3xl text-white/90 font-light leading-relaxed tracking-widest whitespace-nowrap">
               {t("introLine1")}
             </div>
-            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-[0%] text-center text-lg sm:text-2xl lg:text-3xl text-white leading-relaxed tracking-wide lg:tracking-wider whitespace-nowrap">
+            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-[0%] text-center text-lg sm:text-2xl lg:text-3xl text-white/90 font-light leading-relaxed tracking-widest whitespace-nowrap">
               {t("introLine1-1")}
             </div>
           </motion.div>
@@ -102,10 +102,10 @@ export const IntroLine: React.FC = () => {
             style={{ opacity: endIntroLine }}
             className={`absolute inset-0 z-0`}
           >
-            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-[100%] text-center text-lg sm:text-2xl lg:text-3xl text-black leading-relaxed tracking-wide lg:tracking-wider whitespace-nowrap">
+            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-[100%] text-center text-lg sm:text-2xl lg:text-3xl text-gray-800 font-light leading-relaxed tracking-widest whitespace-nowrap">
               {t("introLine2")}
             </div>
-            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-[0%] text-center text-lg sm:text-2xl lg:text-3xl text-black leading-relaxed tracking-wide lg:tracking-wider whitespace-nowrap">
+            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-[0%] text-center text-lg sm:text-2xl lg:text-3xl text-gray-800 font-light leading-relaxed tracking-widest whitespace-nowrap">
               {t("introLine2-1")}
             </div>
           </motion.div>

--- a/src/components/AboutMe/MainPhrase1to4.tsx
+++ b/src/components/AboutMe/MainPhrase1to4.tsx
@@ -39,9 +39,9 @@ export const MainPhrase1to4: React.FC = () => {
       <div className="sticky top-0 h-screen w-full overflow-hidden">
         <div className='absolute inset-0 bg-gradient-to-br from-blue-200 to-purple-200 text-gray-900'>
           {/* 시작 콘텐츠 */}
-          <p className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-lg sm:text-2xl lg:text-3xl tracking-wide lg:tracking-wider whitespace-nowrap">
-              <span className="text-2xl sm:text-3xl lg:text-4xl font-extrabold leading-tight">{t('mainPhrase1')}</span>{t('mainPhrase2')}{' '}
-              <span className="text-2xl sm:text-3xl lg:text-4xl font-extrabold leading-tight">{t('mainPhrase3')}</span>{t('mainPhrase4')}
+          <p className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-lg sm:text-2xl lg:text-3xl tracking-widest whitespace-nowrap">
+              <span className="text-2xl sm:text-3xl lg:text-4xl font-black tracking-tight">{t('mainPhrase1')}</span><span className="font-thin">{t('mainPhrase2')}</span>{' '}
+              <span className="text-2xl sm:text-3xl lg:text-4xl font-black tracking-tight">{t('mainPhrase3')}</span><span className="font-thin">{t('mainPhrase4')}</span>
           </p>
           
           {/* 중간 콘텐츠: 노을 배경 */}
@@ -54,9 +54,9 @@ export const MainPhrase1to4: React.FC = () => {
             }}
           />
 
-          <p className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-lg sm:text-2xl lg:text-3xl tracking-wide lg:tracking-wider whitespace-nowrap">
-              <span className="text-2xl sm:text-3xl lg:text-4xl font-extrabold leading-tight">{t('mainPhrase1')}</span>{t('mainPhrase2')}{' '}
-              <span className="text-2xl sm:text-3xl lg:text-4xl font-extrabold leading-tight">{t('mainPhrase3')}</span>{t('mainPhrase4')}
+          <p className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-lg sm:text-2xl lg:text-3xl tracking-widest whitespace-nowrap">
+              <span className="text-2xl sm:text-3xl lg:text-4xl font-black tracking-tight">{t('mainPhrase1')}</span><span className="font-thin">{t('mainPhrase2')}</span>{' '}
+              <span className="text-2xl sm:text-3xl lg:text-4xl font-black tracking-tight">{t('mainPhrase3')}</span><span className="font-thin">{t('mainPhrase4')}</span>
           </p>
 
 

--- a/src/components/AboutMe/MainPhrase5to8.tsx
+++ b/src/components/AboutMe/MainPhrase5to8.tsx
@@ -65,18 +65,18 @@ export const MainPhrase5to8: React.FC = () => {
           >
             <div className="relative z-20 flex h-full w-full items-center justify-center">
               <p
-                className="text-center text-lg sm:text-2xl lg:text-3xl tracking-wide lg:tracking-wider whitespace-nowrap"
+                className="text-center text-lg sm:text-2xl lg:text-3xl tracking-widest whitespace-nowrap"
                 style={{
                   textShadow: isSwitchedOn ? '0 0 10px rgba(0, 0, 0, 1), 0 0 10px rgba(0, 0, 0, 1), 0 0 10px rgba(0, 0, 0, 1)' : 'none',
-                  transition: 'text-shadow 0.7s ease-in-out', // 부드러운 그림자 효과 전환
+                  transition: 'text-shadow 0.7s ease-in-out',
                 }}
               >
-                <span className="text-2xl sm:text-3xl lg:text-4xl font-extrabold leading-tight">
+                <span className="text-2xl sm:text-3xl lg:text-4xl font-black tracking-tight">
                   {t('mainPhrase5')}
                 </span>
-                {t('mainPhrase6')}{' '}
+                <span className="font-thin">{t('mainPhrase6')}</span>{' '}
                 <motion.span
-                  className="text-2xl sm:text-3xl lg:text-4xl font-extrabold leading-tight text-yellow-300"
+                  className="text-2xl sm:text-3xl lg:text-4xl font-black tracking-tight text-yellow-300"
                   animate={{ opacity: isSwitchedOn ? 1 : 0 }}
                   transition={
                     isSwitchedOn
@@ -86,7 +86,7 @@ export const MainPhrase5to8: React.FC = () => {
                 >
                   {t('mainPhrase7')}
                 </motion.span>
-                {t('mainPhrase8')}
+                <span className="font-thin">{t('mainPhrase8')}</span>
               </p>
             </div>
           </motion.div>


### PR DESCRIPTION
## Summary

- About Me 섹션 전체 타이포그래피 개선
- 서사 텍스트(IntroLine): font-light + tracking-widest로 가볍고 여유 있는 느낌
- 핵심 단어(아이디어, 실현, 문제, 해결): font-black + tracking-tight로 강한 임팩트
- 연결어(를, 하고, 하는): font-thin으로 핵심어와 굵기 대비 강조
- 마지막 문구(개발자 노기윤입니다): font-black + tracking-tight로 강한 마무리

## Test plan

- [ ] IntroLine 서사 텍스트 스타일 확인
- [ ] 핵심어/연결어 굵기 대비 확인
- [ ] DeveloperIntro 마지막 문구 확인
- [ ] 모바일 레이아웃 깨짐 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)