### PR TITLE
fix: eliminate double loading in profile section

### DIFF
--- a/src/sections/home/ProfileSection.tsx
+++ b/src/sections/home/ProfileSection.tsx
@@ -439,8 +439,21 @@ const ProfileSection: React.FC = () => {
     }
   };
 
+  if (!data) {
+    return (
+      <section className="relative min-h-screen w-full">
+        <div className="fixed inset-0 z-0 bg-gradient-to-br from-white via-slate-50 to-slate-100 pointer-events-none" />
+      </section>
+    );
+  }
+
   return (
-    <section className="relative min-h-screen w-full">
+    <motion.section
+      className="relative w-full"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.3, ease: "easeOut" }}
+    >
       <div className="fixed inset-0 z-0 bg-gradient-to-br from-white via-slate-50 to-slate-100 pointer-events-none" />
 
       {/* Mobile-only: fixed bottom tab bar */}
@@ -467,7 +480,6 @@ const ProfileSection: React.FC = () => {
         </div>
       </div>
 
-      {/* pb-20 on mobile to avoid content hiding behind bottom tab bar */}
       <div className="relative z-10 mx-auto max-w-5xl px-4 sm:px-6 pb-28 sm:pb-16 pt-24 sm:pt-28">
         <div className="grid grid-cols-1 gap-8 sm:grid-cols-[3fr_7fr]">
 
@@ -500,16 +512,15 @@ const ProfileSection: React.FC = () => {
           >
             <AnimatePresence mode="wait">
               <motion.div
-                key={data ? activeTab : "__loading__"}
+                key={activeTab}
                 variants={contentVariants}
                 initial="hidden"
                 animate="show"
                 exit="exit"
               >
-                {!data && <p className="text-sm text-slate-400">Loading...</p>}
-                {data && activeTab === "workSkills" && <WorkSkillsTab data={data} />}
-                {data && activeTab === "education" && <EducationTab data={data.education} />}
-                {data && activeTab === "awardsAndCerts" && (
+                {activeTab === "workSkills" && <WorkSkillsTab data={data} />}
+                {activeTab === "education" && <EducationTab data={data.education} />}
+                {activeTab === "awardsAndCerts" && (
                   <AwardsAndCertsTab awards={data.awards} certs={data.certificates} />
                 )}
               </motion.div>
@@ -518,7 +529,7 @@ const ProfileSection: React.FC = () => {
 
         </div>
       </div>
-    </section>
+    </motion.section>
   );
 };
 


### PR DESCRIPTION
## Summary

프로필 섹션에서 "사이드바 먼저 나오고 → 컨텐츠 나중에 로딩되는" 이중 로딩 느낌 제거

**원인**: data가 null인 동안 사이드바는 먼저 렌더, 데이터 로드 후 컨텐츠가 별도 애니메이션
**수정**: 데이터 로드 전엔 배경만 표시, 로드 완료 후 사이드바 + 컨텐츠를 한 번에 fade in

## Test plan

- [ ] 프로필 탭 진입 시 한 번만 로딩되는지 확인
- [ ] 탭 전환 애니메이션 정상 동작 확인
- [ ] 빌드 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)