### PR TITLE
feat: hide header on initial landing page visit

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,9 +19,12 @@ const getInitialTab = () => {
 const AppContent: React.FC = () => {
   const [isModalOpen, setModalOpen] = useState(false);
   const [activeTab, setActiveTab] = useState(getInitialTab);
-  const [headerTranslate, setHeaderTranslate] = useState(0);
-  const lastScrollY = useRef(0);
   const HEADER_HEIGHT = 80;
+  const [headerTranslate, setHeaderTranslate] = useState(() =>
+    window.location.pathname === '/' ? -HEADER_HEIGHT : 0
+  );
+  const lastScrollY = useRef(0);
+  const headerRevealed = useRef(window.location.pathname !== '/');
   
   const location = useLocation();
 
@@ -44,10 +47,13 @@ const AppContent: React.FC = () => {
       }
 
       if (currentScrollY <= 0) {
-        setHeaderTranslate(0);
+        if (headerRevealed.current) {
+          setHeaderTranslate(0);
+        }
         lastScrollY.current = 0;
         return;
       }
+      headerRevealed.current = true;
       setHeaderTranslate((prev) =>
         Math.max(-HEADER_HEIGHT, Math.min(0, prev - delta))
       );


### PR DESCRIPTION
## Summary
- 메인 페이지(`/`) 최초 진입 시 상단 헤더를 숨김 처리
- 스크롤 시 자연스럽게 헤더가 나타나도록 `headerRevealed` ref로 제어
- 프로젝트 상세 페이지(`/project/:id`)는 기존처럼 헤더가 바로 표시됨

## Test plan
- [ ] 메인 페이지 첫 진입 시 상단바가 보이지 않는지 확인
- [ ] 스크롤을 내렸다가 올렸을 때 상단바가 나타나는지 확인
- [ ] 프로젝트 상세 페이지 진입 시 상단바가 정상 표시되는지 확인
- [ ] 상단바 나타난 후 기존 스크롤 숨김/표시 동작이 정상인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)