### PR TITLE
feat: add claudeInfo protocol and apply to BOJ Snippets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,3 +42,80 @@
 | 가짜 UI, 예쁜 드롭다운 | 커스텀 UI, 커스텀 드롭다운 |
 | 삽질을 했다, 발목을 잡았다 | 다수의 시도를 진행함, 제약 사항이 존재함 |
 | 3번 실패하고 4번째에 성공 | 다수의 시도 끝에 해결 |
+
+# Claude 협업 정보 프로토콜 (claudeInfo)
+
+Claude를 활용하여 개발한 프로젝트에 협업 방식을 기록하기 위한 양식.
+
+## 타입 정의 (`src/types/index.ts`)
+
+```ts
+interface ClaudeInfo {
+  method: 'direct' | 'harness' | 'orchestrator';
+  summary: string;        // i18n key — 한 줄 요약
+  agents?: ClaudeAgent[]; // 하네스 에이전트 목록 (direct에서는 생략)
+  flow?: string[];        // i18n keys — 실행 흐름 단계 (direct에서는 생략)
+  details?: string;       // i18n key — 추가 설명
+}
+```
+
+## 적용 위치
+
+### 1. `projects-list.json` (카드 뱃지 표시용)
+```json
+{
+  "id": "project-id",
+  "claudeInfo": {
+    "method": "direct",
+    "summary": "project-id.claudeInfo.summary"
+  }
+}
+```
+
+### 2. `projects/{project-id}.json` (상세 페이지용)
+```json
+{
+  "claudeInfo": {
+    "method": "direct",
+    "summary": "project-id.claudeInfo.summary",
+    "details": "project-id.claudeInfo.details"
+  }
+}
+```
+
+### 3. i18n 번역 파일 (`project-{project-id}.json`)
+```json
+{
+  "claudeInfo": {
+    "summary": "한 줄 요약",
+    "details": "상세 설명"
+  }
+}
+```
+
+## method별 사용 예시
+
+### direct — 단일 Claude 직접 사용
+```json
+{
+  "method": "direct",
+  "summary": "i18n-key",
+  "details": "i18n-key"
+}
+```
+
+### harness — 멀티에이전트 하네스 사용
+```json
+{
+  "method": "harness",
+  "summary": "i18n-key",
+  "agents": [
+    { "name": "Architect", "role": "i18n-key", "permissions": "readonly" },
+    { "name": "Coder", "role": "i18n-key", "permissions": "bypassPermissions" },
+    { "name": "Debugger", "role": "i18n-key", "permissions": "readonly" },
+    { "name": "Reviewer", "role": "i18n-key", "permissions": "readonly" }
+  ],
+  "flow": ["i18n-key-step1", "i18n-key-step2", "i18n-key-step3"],
+  "details": "i18n-key"
+}
+```

--- a/public/data/projects-list.json
+++ b/public/data/projects-list.json
@@ -47,6 +47,10 @@
     "subtitle": "boj-snippets.subtitle",
     "projectType": "boj-snippets.overview.projectType",
     "screenshots": [{ "src": "/images/bojSnippets/Icon.png", "alt": "BOJ Snippets Thumbnail" }],
-    "techStack": ["Chrome Extension", "Manifest V3", "JavaScript"]
+    "techStack": ["Chrome Extension", "Manifest V3", "JavaScript"],
+    "claudeInfo": {
+      "method": "direct",
+      "summary": "boj-snippets.claudeInfo.summary"
+    }
   }
 ]

--- a/public/data/projects/boj-snippets.json
+++ b/public/data/projects/boj-snippets.json
@@ -210,5 +210,10 @@
       "content": "boj-snippets.developmentProcess.2.content"
     }
   ],
-  "license": { "name": "MIT", "url": "https://opensource.org/licenses/MIT" }
+  "license": { "name": "MIT", "url": "https://opensource.org/licenses/MIT" },
+  "claudeInfo": {
+    "method": "direct",
+    "summary": "boj-snippets.claudeInfo.summary",
+    "details": "boj-snippets.claudeInfo.details"
+  }
 }

--- a/public/locales/en/projects/project-boj-snippets.json
+++ b/public/locales/en/projects/project-boj-snippets.json
@@ -103,6 +103,10 @@
         "title": "Stabilization and Release",
         "content": "Addressed Chosen library compatibility, implemented options page, and completed chrome.storage.sync-based storage structure"
       }
-    ]
+    ],
+    "claudeInfo": {
+      "summary": "Built with Claude",
+      "details": "Developed from design to implementation using Claude Code CLI as a single agent. No harness was used; development was conducted through direct conversation."
+    }
   }
 }

--- a/public/locales/ko/projects/project-boj-snippets.json
+++ b/public/locales/ko/projects/project-boj-snippets.json
@@ -103,6 +103,10 @@
         "title": "안정화 및 배포",
         "content": "Chosen 라이브러리 대응, 옵션 페이지 구현, chrome.storage.sync 기반 저장 구조 완성 후 Chrome Web Store 배포"
       }
-    ]
+    ],
+    "claudeInfo": {
+      "summary": "Claude를 활용하여 개발함",
+      "details": "Claude Code CLI를 단일 에이전트로 활용하여 설계부터 구현까지 진행함. 하네스 없이 직접 대화 방식으로 개발을 수행함."
+    }
   }
 }

--- a/src/components/PortfolioCard/index.tsx
+++ b/src/components/PortfolioCard/index.tsx
@@ -66,6 +66,21 @@ const PortfolioCard: React.FC<PortfolioCardProps> = ({ project, className, onCli
                                 </span>
                             </div>
                         </div>
+                            {project.claudeInfo && (
+                                <div
+                                    className="
+                                        pointer-events-none select-none
+                                        absolute top-3 right-3
+                                        flex items-center
+                                        px-2.5 py-1
+                                        rounded-full shadow-md
+                                        bg-[#c66240]
+                                    "
+                                    aria-hidden
+                                >
+                                    <span className="text-white text-[10px] font-bold tracking-wide">Claude</span>
+                                </div>
+                            )}
                             {project.stickerText && (
                                 <div
                                 className={`

--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -109,6 +109,14 @@ const ProjectDetailPage: React.FC = () => {
             <p className="text-base sm:text-lg text-slate-500 max-w-xl mx-auto">
               {t(project.subtitle, { ns: `projects/project-${projectId}` })}
             </p>
+            {project.claudeInfo && (
+              <div className="mt-4 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-[#c66240]/10">
+                <span className="w-2 h-2 rounded-full bg-[#c66240]" />
+                <span className="text-sm text-[#c66240] font-medium">
+                  {t(project.claudeInfo.summary, { ns: `projects/project-${projectId}` })}
+                </span>
+              </div>
+            )}
           </header>
 
           {/* Demo GIF */}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,6 +28,20 @@ export interface Feature { name: string; description: string; icon: IconType; }
 export interface Screenshot { title: string; src: string; }
 export interface DevelopmentStep { title: string; content: string; }
 
+export interface ClaudeAgent {
+  name: string;
+  role: string;           // i18n key
+  permissions?: 'readonly' | 'bypassPermissions';
+}
+
+export interface ClaudeInfo {
+  method: 'direct' | 'harness' | 'orchestrator';
+  summary: string;        // i18n key — 한 줄 요약
+  agents?: ClaudeAgent[]; // 하네스 에이전트 목록 (direct에서는 생략)
+  flow?: string[];        // i18n keys — 실행 흐름 단계 (direct에서는 생략)
+  details?: string;       // i18n key — 추가 설명 (구조, 설정, 특이사항)
+}
+
 export interface ProjectSummary {
     id: string;
     title: string;
@@ -38,6 +52,7 @@ export interface ProjectSummary {
     stickerText?: string;
     stickerColor?: string;
     stickerIcon?: string;
+    claudeInfo?: ClaudeInfo;
 }
 
 // '개요' 섹션을 위한 타입
@@ -70,6 +85,7 @@ export interface ProjectData {
     name: string;
     url: string;
   };
+  claudeInfo?: ClaudeInfo;
 
   // 확장성을 위해 수정된 부분
   overview: ProjectOverview;


### PR DESCRIPTION
## Summary
- `ClaudeInfo` 타입 정의 (direct / harness / orchestrator 지원)
- BOJ Snippets 프로젝트에 `claudeInfo` 데이터 적용
- 카드 우상단 Claude 뱃지 표시 + 상세 페이지 헤더에 협업 정보 표시
- CLAUDE.md에 claudeInfo 프로토콜 문서화

## Test plan
- [ ] BOJ Snippets 카드에 Claude 뱃지 표시 확인
- [ ] BOJ Snippets 상세 페이지 헤더에 협업 문구 표시 확인
- [ ] 다른 프로젝트 카드에는 뱃지 미표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)