### PR TITLE
feat: apply rounded border to portfolio card images

### DIFF
--- a/src/components/PortfolioCard/index.tsx
+++ b/src/components/PortfolioCard/index.tsx
@@ -42,12 +42,14 @@ const PortfolioCard: React.FC<PortfolioCardProps> = ({ project, className, onCli
                 >
                     <div className="absolute w-full h-full" style={{ backfaceVisibility: 'hidden' }}>
                         <div className="bg-white rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-300 overflow-hidden flex flex-col h-full">
-                            <img
-                                src={project.screenshots.length > 0 ? project.screenshots[0].src : "https://placehold.co/300x300/cccccc/333333?text=Project+Image"}
-                                alt={`${t(project.title || '')} Thumbnail`}
-                                className="w-full aspect-square object-contain p-4"
-                                onError={handleImageError}
-                            />
+                            <div className="p-4">
+                                <img
+                                    src={project.screenshots.length > 0 ? project.screenshots[0].src : "https://placehold.co/300x300/cccccc/333333?text=Project+Image"}
+                                    alt={`${t(project.title || '')} Thumbnail`}
+                                    className="w-full aspect-square object-contain rounded-[3rem]"
+                                    onError={handleImageError}
+                                />
+                            </div>
                         <div className="px-6 pb-4 flex flex-col flex-grow overflow-y-auto">
                             <h3 className="text-2xl font-bold mb-2 truncate">
                                 {t(project.title || '')}


### PR DESCRIPTION
## Summary
- 카드 썸네일 이미지에 `rounded-[3rem]` border 적용
- 이미지를 `div.p-4` 래퍼로 감싸 padding과 border-radius 분리

## Test plan
- [ ] 모든 프로젝트 카드 이미지에 둥근 모서리 적용 확인
- [ ] 카드 뒤집기 애니메이션 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)