### PR TITLE
feat: rebrand claudeInfo badge to Vibe Coding

### DIFF
--- a/public/locales/en/projects/project-boj-snippets.json
+++ b/public/locales/en/projects/project-boj-snippets.json
@@ -105,7 +105,7 @@
       }
     ],
     "claudeInfo": {
-      "summary": "Built with Claude",
+      "summary": "Developed with Vibe Coding",
       "details": "Developed from design to implementation using Claude Code CLI as a single agent. No harness was used; development was conducted through direct conversation."
     }
   }

--- a/public/locales/ko/projects/project-boj-snippets.json
+++ b/public/locales/ko/projects/project-boj-snippets.json
@@ -105,7 +105,7 @@
       }
     ],
     "claudeInfo": {
-      "summary": "Claude를 활용하여 개발함",
+      "summary": "바이브 코딩으로 개발함",
       "details": "Claude Code CLI를 단일 에이전트로 활용하여 설계부터 구현까지 진행함. 하네스 없이 직접 대화 방식으로 개발을 수행함."
     }
   }

--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -110,9 +110,9 @@ const ProjectDetailPage: React.FC = () => {
               {t(project.subtitle, { ns: `projects/project-${projectId}` })}
             </p>
             {project.claudeInfo && (
-              <div className="mt-4 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-[#c66240]/10">
-                <span className="w-2 h-2 rounded-full bg-[#c66240]" />
-                <span className="text-sm text-[#c66240] font-medium">
+              <div className="mt-4 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border border-indigo-200 bg-indigo-50">
+                <span className="w-2 h-2 rounded-full bg-indigo-400" />
+                <span className="text-sm text-indigo-600 font-medium">
                   {t(project.claudeInfo.summary, { ns: `projects/project-${projectId}` })}
                 </span>
               </div>


### PR DESCRIPTION
## Summary
- claudeInfo 뱃지 텍스트: "Claude를 활용하여 개발함" → "바이브 코딩으로 개발함"
- 상세 페이지 뱃지 스타일: `#c66240`(오렌지) → `indigo` 계열로 통일
- en/ko 번역 파일 동시 반영

## Test plan
- [ ] 프로젝트 상세 페이지에서 claudeInfo 뱃지 텍스트 확인 (ko/en)
- [ ] 뱃지 스타일이 indigo 계열로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)