### PR TITLE
docs: add branch rule — feature branches must fork from develop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,6 @@
 # Branch Management Rules
 
+- feature 브랜치는 반드시 `develop` 브랜치에서 분기한다 (`git checkout develop && git checkout -b feat/...`)
 - 기능별로 feature 브랜치를 생성한다 (예: `feat/add-boj-snippets`)
 - 커밋 명령 시 develop 브랜치로 Pull Request를 생성하는 것을 원칙으로 한다
 - PR 대상 브랜치: `develop`


### PR DESCRIPTION
## Summary
- CLAUDE.md에 feature 브랜치는 반드시 `develop`에서 분기한다는 규칙 추가

## Test plan
- [ ] CLAUDE.md Branch Management Rules 섹션 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)