### PR TITLE
Align AI DevKit modal styling with tokens

### DIFF
--- a/src/components/AiDevKitModal/DetailItems.tsx
+++ b/src/components/AiDevKitModal/DetailItems.tsx
@@ -48,9 +48,9 @@ const StepBadges: React.FC<{ item: AiDevKitDetailItem }> = ({ item }) => {
       {item.steps.map((step, index) => (
         <span
           key={`${item.title}-${step}`}
-          className="inline-flex items-center gap-2 rounded-full bg-slate-900 px-3 py-1.5 text-xs font-semibold text-white"
+          className="inline-flex items-center gap-2 rounded-full border border-line bg-content px-3 py-1.5 text-xs font-semibold text-surface shadow-sm"
         >
-          <span className="text-slate-300">{index + 1}.</span>
+          <span className="text-surface/70">{index + 1}.</span>
           {step}
         </span>
       ))}
@@ -125,7 +125,7 @@ const CodeSamples: React.FC<{ itemTitle: string; samples?: AiDevKitCodeSample[] 
               </span>
             )}
           </div>
-          <pre className="mt-3 overflow-x-auto rounded-card border border-line bg-slate-950 p-4 text-[11px] leading-relaxed text-slate-100">
+          <pre className="mt-3 overflow-x-auto rounded-card border border-line/70 bg-content p-4 text-[11px] leading-relaxed text-surface shadow-sm">
             <code>{sample.code}</code>
           </pre>
         </div>
@@ -135,14 +135,14 @@ const CodeSamples: React.FC<{ itemTitle: string; samples?: AiDevKitCodeSample[] 
 };
 
 const DiagramItems: React.FC<DetailItemsProps> = ({ section }) => (
-  <div className="rounded-card bg-surface-subtle p-4 shadow-lg sm:p-5">
+  <div className="rounded-card border border-line/70 bg-surface-subtle p-4 shadow-sm sm:p-5">
     <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
       {section.items?.map((detailItem, index) => (
         <article
           key={`${section.title}-${detailItem.title}`}
-          className="rounded-card bg-surface p-4 shadow-lg"
+          className="rounded-card border border-line/70 bg-surface p-4 shadow-sm"
         >
-          <div className="mb-3 inline-flex h-6 min-w-[28px] items-center justify-center rounded-full bg-accent-600 px-1.5 text-[11px] font-bold text-white">
+          <div className="mb-3 inline-flex h-6 min-w-[28px] items-center justify-center rounded-full bg-accent-600 px-1.5 text-[11px] font-bold text-surface">
             {String(index + 1).padStart(2, '0')}
           </div>
           <DetailItemHeading item={detailItem} />
@@ -157,10 +157,10 @@ const FlowItems: React.FC<DetailItemsProps> = ({ section }) => (
     {section.items?.map((detailItem) => (
       <article
         key={`${section.title}-${detailItem.title}`}
-        className="rounded-card bg-surface p-5 shadow-lg"
+        className="rounded-card border border-line/70 bg-surface p-5 shadow-sm"
       >
         <div className="mb-5">
-          <div className="inline-flex items-center rounded-full bg-slate-900 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-white">
+          <div className="inline-flex items-center rounded-full border border-line bg-content px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-surface shadow-sm">
             Harness Run
           </div>
           <h5 className="mt-4 text-base font-bold text-content-strong">
@@ -192,7 +192,7 @@ const CardItems: React.FC<DetailItemsProps> = ({ section }) => (
     {section.items?.map((detailItem) => (
       <article
         key={`${section.title}-${detailItem.title}`}
-        className={`rounded-card bg-surface p-4 ${
+        className={`rounded-card border border-line/70 bg-surface p-4 shadow-sm ${
           detailItem.groups?.length ? 'md:col-span-2' : ''
         } ${
           detailItem.iconKey &&
@@ -217,7 +217,7 @@ const CardItems: React.FC<DetailItemsProps> = ({ section }) => (
             {detailItem.groups.map((group) => (
               <div
                 key={`${detailItem.title}-${group.title}`}
-                className="rounded-card bg-surface-subtle p-4"
+                className="rounded-card border border-line/70 bg-surface-subtle p-4"
               >
                 <h6 className="text-xs font-semibold uppercase tracking-[0.16em] text-accent-700">
                   {group.title}

--- a/src/components/AiDevKitModal/DetailSection.tsx
+++ b/src/components/AiDevKitModal/DetailSection.tsx
@@ -17,9 +17,9 @@ const SectionStepPills: React.FC<{ section: AiDevKitDetailSection }> = ({
       {section.steps.map((step, index) => (
         <div
           key={`${section.title}-${step}`}
-          className="inline-flex items-center gap-2 rounded-full bg-accent-50 px-3 py-2 text-xs font-semibold text-accent-700"
+          className="inline-flex items-center gap-2 rounded-full border border-line bg-surface-subtle px-3 py-2 text-xs font-semibold text-content-secondary"
         >
-          <span className="flex h-5 w-5 items-center justify-center rounded-full bg-accent-600 text-[11px] text-white">
+          <span className="flex h-5 w-5 items-center justify-center rounded-full bg-accent-600 text-[11px] text-surface">
             {index + 1}
           </span>
           {step}
@@ -30,7 +30,7 @@ const SectionStepPills: React.FC<{ section: AiDevKitDetailSection }> = ({
 };
 
 const DetailSection: React.FC<DetailSectionProps> = ({ section }) => (
-  <section className="rounded-card bg-surface p-5">
+  <section className="rounded-card border border-line/70 bg-surface p-5 shadow-sm">
     <div className="mb-4">
       <h4 className="text-lg font-bold text-content">{section.title}</h4>
       {section.description && (

--- a/src/components/AiDevKitModal/FlowDiagram.tsx
+++ b/src/components/AiDevKitModal/FlowDiagram.tsx
@@ -151,8 +151,8 @@ const FlowStepCard: React.FC<{
   <div
     className={`${className} flex min-h-[132px] flex-col items-center justify-center rounded-card px-4 py-3 text-center ${
       highlighted
-        ? 'border-2 border-accent-300 bg-accent-50'
-        : 'border border-line bg-surface-subtle'
+        ? 'border-2 border-accent-100 bg-accent-50'
+        : 'border border-line/70 bg-surface'
     }`}
     style={style}
   >
@@ -188,7 +188,7 @@ const LoopStepCard: React.FC<{
   style?: React.CSSProperties;
 }> = ({ item, className = '', style }) => (
   <div
-    className={`${className} flex flex-col items-center justify-center rounded-card border-2 border-accent-300 bg-accent-50 px-3 py-2.5 text-center`}
+    className={`${className} flex flex-col items-center justify-center rounded-card border-2 border-accent-100 bg-accent-50 px-3 py-2.5 text-center`}
     style={style}
   >
     <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-accent-700">
@@ -232,7 +232,7 @@ const LoopLabels: React.FC<{ loops: AiDevKitFlowLoop[] }> = ({ loops }) => {
           key={`${loop.fromStep}-${loop.toStep}-${index}`}
           className="flex items-start gap-2 text-xs font-medium leading-relaxed text-content-secondary"
         >
-          <span className="mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-accent-600 text-white">
+          <span className="mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-accent-600 text-surface">
             <svg
               className="h-2.5 w-2.5"
               viewBox="0 0 16 16"
@@ -421,7 +421,7 @@ const FlowDiagram: React.FC<FlowDiagramProps> = ({
                   id={arrowMarkerId}
                   markerWidth="5"
                   markerHeight="5"
-                  refX="5"
+                  refX="4"
                   refY="2.5"
                   orient="auto"
                   markerUnits="strokeWidth"

--- a/src/components/AiDevKitModal/ModalHeader.tsx
+++ b/src/components/AiDevKitModal/ModalHeader.tsx
@@ -8,7 +8,7 @@ interface ModalHeaderProps {
 }
 
 const ModalHeader: React.FC<ModalHeaderProps> = ({ item, onClose }) => (
-  <div className="flex items-start justify-between gap-4 border-b border-line bg-surface p-6">
+  <div className="flex items-start justify-between gap-4 border-b border-line bg-surface-subtle/70 p-6">
     <div className="flex min-w-0 items-start gap-4">
       <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-accent-50 text-accent-600">
         {item.icon}
@@ -26,7 +26,7 @@ const ModalHeader: React.FC<ModalHeaderProps> = ({ item, onClose }) => (
     <button
       type="button"
       onClick={onClose}
-      className="rounded-full border border-line bg-surface p-2 text-content-muted transition-colors duration-200 hover:text-content"
+      className="rounded-full border border-line bg-surface p-2 text-content-muted transition-colors duration-200 hover:bg-surface-subtle hover:text-content"
       aria-label={item.closeLabel}
     >
       <CloseIcon />

--- a/src/components/AiDevKitModal/SkillGroups.tsx
+++ b/src/components/AiDevKitModal/SkillGroups.tsx
@@ -259,13 +259,13 @@ const SkillModuleDiagram: React.FC<{ skillItem: AiDevKitSkillItem }> = ({
   const insetPercent = moduleCount > 0 ? 50 / moduleCount : 0;
 
   return (
-    <div className="rounded-card bg-surface-subtle p-5 md:p-6">
+    <div className="rounded-card border border-line/70 bg-surface-subtle p-5 md:p-6">
       <div className="flex justify-center">
-        <div className="rounded-2xl bg-slate-900 px-5 py-3 text-center shadow-sm">
-          <div className="inline-flex rounded-full border border-white/15 bg-white/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-white shadow-sm">
+        <div className="rounded-modal border border-line bg-content px-5 py-3 text-center shadow-sm">
+          <div className="inline-flex rounded-full border border-surface/15 bg-surface/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-surface shadow-sm">
             Skill
           </div>
-          <div className="mt-1 text-sm font-bold text-white">
+          <div className="mt-1 text-sm font-bold text-surface">
             {skillItem.title}
           </div>
         </div>
@@ -294,8 +294,8 @@ const SkillModuleDiagram: React.FC<{ skillItem: AiDevKitSkillItem }> = ({
               className="relative flex flex-col items-center pt-6"
             >
               <div className="absolute left-1/2 top-0 h-6 w-px -translate-x-1/2 bg-line" />
-              <div className="flex h-full w-full flex-col items-center justify-start rounded-2xl bg-surface px-3 py-3 text-center shadow-sm">
-                <div className="inline-flex h-6 min-w-[28px] items-center justify-center rounded-full bg-accent-600 px-1.5 text-[11px] font-bold text-white">
+              <div className="flex h-full w-full flex-col items-center justify-start rounded-card border border-line/70 bg-surface px-3 py-3 text-center shadow-sm">
+                <div className="inline-flex h-6 min-w-[28px] items-center justify-center rounded-full bg-accent-600 px-1.5 text-[11px] font-bold text-surface">
                   {String(index + 1).padStart(2, '0')}
                 </div>
                 <div className="mt-1.5 text-sm font-bold text-content">
@@ -311,8 +311,8 @@ const SkillModuleDiagram: React.FC<{ skillItem: AiDevKitSkillItem }> = ({
         <div className="h-4 w-px bg-line" />
         {skillItem.sections.map((groupSection, index) => (
           <React.Fragment key={`${skillItem.title}-mobile-${groupSection.title}`}>
-            <div className="inline-flex items-center gap-2 rounded-2xl bg-surface px-3 py-2 shadow-sm">
-              <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-accent-600 text-[10px] font-bold text-white">
+            <div className="inline-flex items-center gap-2 rounded-card border border-line/70 bg-surface px-3 py-2 shadow-sm">
+              <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-accent-600 text-[10px] font-bold text-surface">
                 {index + 1}
               </span>
               <span className="text-sm font-bold text-content">
@@ -369,7 +369,7 @@ const SkillSectionCard: React.FC<{
 const SkillItemCard: React.FC<{ skillItem: AiDevKitSkillItem }> = ({
   skillItem,
 }) => (
-  <article className="rounded-card bg-surface p-5 shadow-lg">
+  <article className="rounded-card border border-line/70 bg-surface p-5 shadow-sm">
     <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="max-w-3xl">

--- a/src/components/AiDevKitModal/icons.tsx
+++ b/src/components/AiDevKitModal/icons.tsx
@@ -5,7 +5,7 @@ export const DetailIcon: React.FC<{ iconKey?: string }> = ({ iconKey }) => {
 
   if (iconKey === 'unity') {
     return (
-      <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-slate-900 text-base font-black text-white">
+      <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-line bg-content text-base font-black text-surface shadow-sm">
         U
       </div>
     );
@@ -13,7 +13,7 @@ export const DetailIcon: React.FC<{ iconKey?: string }> = ({ iconKey }) => {
 
   if (iconKey === 'blender') {
     return (
-      <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-orange-500 text-base font-black text-white">
+      <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-line bg-accent-600 text-base font-black text-surface shadow-sm">
         B
       </div>
     );

--- a/src/components/AiDevKitModal/index.tsx
+++ b/src/components/AiDevKitModal/index.tsx
@@ -48,12 +48,12 @@ const AiDevKitModal: React.FC<AiDevKitModalProps> = ({ item, onClose }) => {
       onClick={onClose}
     >
       <div
-        className="w-full max-w-5xl overflow-hidden rounded-card bg-surface shadow-[0_24px_64px_rgba(15,23,42,0.2)] animate-fade-in-up"
+        className="w-full max-w-5xl overflow-hidden rounded-modal border border-line bg-surface shadow-2xl animate-fade-in-up"
         onClick={(event) => event.stopPropagation()}
       >
         <ModalHeader item={item} onClose={onClose} />
 
-        <div className="max-h-[75vh] overflow-y-auto p-6">
+        <div className="max-h-[75vh] overflow-y-auto bg-surface-subtle/40 p-6">
           <div className="space-y-6">
             {item.sections.map((section) => (
               <DetailSection key={section.title} section={section} />


### PR DESCRIPTION
## Summary
- align AI DevKit modal surfaces, borders, badges, and shadows with the existing design tokens
- keep the current layout intact while making the modal styling more consistent across header, sections, diagrams, and skill cards

## Testing
- npm run build
- npm run lint