### PR TITLE
Reset scroll when switching home tabs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,12 @@ const AppContent: React.FC = () => {
   }, [location.pathname]);
 
   useEffect(() => {
+    if (location.pathname === '/') {
+      window.scrollTo(0, 0);
+    }
+  }, [activeTab, location.pathname]);
+
+  useEffect(() => {
     const SCROLL_THRESHOLD = 20;
 
     const handleScroll = () => {


### PR DESCRIPTION
## Summary
- 자기소개 → 프로젝트 등 홈 탭 전환 시 스크롤 위치가 유지되던 문제를 수정함
- `App.tsx`에 `activeTab` 변경 감지 `useEffect` 추가, 홈 경로(`/`)에서만 스크롤을 최상단으로 리셋함
- `ScrollToTop`은 `pathname` 변경만 감시하여 동작하지 않던 한계를 보완함

## Test plan
- [ ] 자기소개 탭에서 스크롤 후 프로젝트 탭 클릭 시 최상단으로 이동하는지 확인
- [ ] 프로젝트 → 포스트 → 프로필 등 다른 탭 전환에서도 동일하게 동작하는지 확인
- [ ] 프로젝트 상세 페이지 진입/뒤로가기 스크롤 동작이 기존과 동일한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)