### PR TITLE
Hide phone card on public profile when empty

### DIFF
--- a/src/sections/home/ProfileSection.tsx
+++ b/src/sections/home/ProfileSection.tsx
@@ -554,19 +554,21 @@ const ResumeProfileCard: React.FC<{
         </button>
       </div>
 
-      <div className="mt-5 grid gap-3 sm:grid-cols-2">
+      <div className={`mt-5 grid gap-3 ${profile.phone ? "sm:grid-cols-2" : ""}`}>
         <div className="rounded-2xl bg-surface-subtle px-4 py-3">
           <p className="text-xs font-semibold uppercase tracking-widest text-content-muted">
             {t("resume.builder.email")}
           </p>
           <p className="mt-1 text-sm font-medium text-content-secondary">{profile.email}</p>
         </div>
-        <div className="rounded-2xl bg-surface-subtle px-4 py-3">
-          <p className="text-xs font-semibold uppercase tracking-widest text-content-muted">
-            {t("resume.builder.phone")}
-          </p>
-          <p className="mt-1 text-sm font-medium text-content-secondary">{profile.phone}</p>
-        </div>
+        {profile.phone && (
+          <div className="rounded-2xl bg-surface-subtle px-4 py-3">
+            <p className="text-xs font-semibold uppercase tracking-widest text-content-muted">
+              {t("resume.builder.phone")}
+            </p>
+            <p className="mt-1 text-sm font-medium text-content-secondary">{profile.phone}</p>
+          </div>
+        )}
       </div>
 
       <div className="mt-4 flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary
- `public/data/resume-profile.json` / `resume-profile.en.json`의 `phone` 필드는 이미 빈 문자열로 비워둠 (이력서 빌더에서 매 제출마다 사용자가 직접 입력).
- 공개 프로필(`ProfileSection`의 `ResumeProfileCard`)에서 `phone`이 빈 값일 때 카드 자체를 렌더링하지 않도록 조건부 처리. 그리드도 phone 있을 때만 `sm:grid-cols-2`, 없으면 1열로 떨어져 빈 슬롯이 안 생김.
- `/resume-preview` 빌더의 phone 입력 칸은 그대로 유지됨 — 사용자가 입력하면 PDF에 반영.

## 배경
원본 데이터에 박혀 있던 휴대폰 번호를 git history에서도 제거(`git filter-repo`)하고, 향후엔 이력서 빌더에서 매번 입력하도록 변경함. 본 PR은 그에 맞춰 사이트 공개 프로필 UI를 정리.

## Test plan
- [ ] 메인 사이트 프로필 카드에서 phone 카드가 보이지 않음 (`profile.phone === ""`)
- [ ] phone 카드 미표시 시 email 카드가 1열로 자연스럽게 풀 너비를 차지
- [ ] `/resume-preview`에서 phone 입력 시 PDF 미리보기에 정상 반영
- [ ] 빌드 성공 (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)