### PR TITLE
Release: hide phone card on public profile

### DIFF
--- a/src/sections/home/ProfileSection.tsx
+++ b/src/sections/home/ProfileSection.tsx
@@ -554,19 +554,21 @@ const ResumeProfileCard: React.FC<{
         </button>
       </div>
 
-      <div className="mt-5 grid gap-3 sm:grid-cols-2">
+      <div className={`mt-5 grid gap-3 ${profile.phone ? "sm:grid-cols-2" : ""}`}>
         <div className="rounded-2xl bg-surface-subtle px-4 py-3">
           <p className="text-xs font-semibold uppercase tracking-widest text-content-muted">
             {t("resume.builder.email")}
           </p>
           <p className="mt-1 text-sm font-medium text-content-secondary">{profile.email}</p>
         </div>
-        <div className="rounded-2xl bg-surface-subtle px-4 py-3">
-          <p className="text-xs font-semibold uppercase tracking-widest text-content-muted">
-            {t("resume.builder.phone")}
-          </p>
-          <p className="mt-1 text-sm font-medium text-content-secondary">{profile.phone}</p>
-        </div>
+        {profile.phone && (
+          <div className="rounded-2xl bg-surface-subtle px-4 py-3">
+            <p className="text-xs font-semibold uppercase tracking-widest text-content-muted">
+              {t("resume.builder.phone")}
+            </p>
+            <p className="mt-1 text-sm font-medium text-content-secondary">{profile.phone}</p>
+          </div>
+        )}
       </div>
 
       <div className="mt-4 flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary
- 공개 프로필(`ProfileSection`의 `ResumeProfileCard`)에서 `phone` 값이 빈 문자열일 때 카드 자체를 렌더링하지 않음. 그리드도 phone 있을 때만 `sm:grid-cols-2`, 없으면 1열로 떨어져 빈 슬롯이 안 생김.
- 데이터 파일의 `phone` 필드는 이미 빈 문자열로 비워둠. `/resume-preview` 빌더의 입력 칸은 그대로 살아있어 사용자가 매 제출마다 직접 입력 후 PDF 생성.

## Test plan
- [ ] 메인 사이트 프로필 카드에서 phone 카드가 보이지 않음
- [ ] phone 카드 미표시 시 email 카드가 1열로 풀 너비
- [ ] `/resume-preview`에서 phone 입력 시 PDF 미리보기에 정상 반영
- [ ] 빌드 성공 (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)