### PR TITLE
Release: basics tab and resume preview header polish

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -108,7 +108,7 @@
     "generating": "Generating resume...",
     "downloadFailed": "Failed to generate resume",
     "preview": "Resume Preview",
-    "openPreview": "Open Resume Preview",
+    "heading": "Resume",
     "backToProfile": "Back to Profile",
     "savePdf": "Save as PDF",
     "resetDraft": "Reset Copy",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -25,6 +25,7 @@
     }
   },
   "profileTabs": {
+    "basics": "Basics",
     "workSkills": "Experience & Skills",
     "education": "Education",
     "awardsAndCerts": "Awards & Certs"

--- a/public/locales/ko/common.json
+++ b/public/locales/ko/common.json
@@ -108,7 +108,7 @@
     "generating": "이력서 생성 중...",
     "downloadFailed": "이력서 생성 실패",
     "preview": "이력서 미리보기",
-    "openPreview": "이력서 미리보기 열기",
+    "heading": "이력서",
     "backToProfile": "프로필로 돌아가기",
     "savePdf": "PDF로 저장",
     "resetDraft": "문구 초기화",

--- a/public/locales/ko/common.json
+++ b/public/locales/ko/common.json
@@ -25,6 +25,7 @@
     }
   },
   "profileTabs": {
+    "basics": "기본정보",
     "workSkills": "경력 & 스킬",
     "education": "학력",
     "awardsAndCerts": "수상 & 자격증"

--- a/src/pages/ResumePreviewPage.tsx
+++ b/src/pages/ResumePreviewPage.tsx
@@ -487,10 +487,7 @@ const ResumePreviewPage: React.FC = () => {
       <div className="mx-auto max-w-7xl px-4 pt-28 pb-10 print:px-0 print:pt-0">
         <div data-print-hidden="true" className="mb-5 flex flex-wrap items-center justify-between gap-3">
           <div>
-            <p className="text-sm font-semibold uppercase tracking-[0.14em] text-slate-500">
-              {t("resume.preview")}
-            </p>
-            <h1 className="mt-1.5 text-3xl font-bold text-slate-950">{t("resume.openPreview")}</h1>
+            <h1 className="text-3xl font-bold text-slate-950">{t("resume.heading")}</h1>
             <p className="mt-1.5 text-sm text-slate-600">{t("resume.helper")}</p>
           </div>
           <div className="flex flex-wrap items-center gap-3">

--- a/src/sections/home/ProfileSection.tsx
+++ b/src/sections/home/ProfileSection.tsx
@@ -547,7 +547,7 @@ const ResumeProfileCard: React.FC<{
           onClick={onOpenPreview}
           className="inline-flex items-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-slate-700"
         >
-          {t("resume.openPreview")}
+          {t("resume.preview")}
         </button>
       </div>
 

--- a/src/sections/home/ProfileSection.tsx
+++ b/src/sections/home/ProfileSection.tsx
@@ -9,7 +9,7 @@ import {
 } from "../../utils/resumePreview";
 
 // ── Types ──────────────────────────────────────────────────────────────────────
-type TabId = "workSkills" | "education" | "awardsAndCerts";
+type TabId = "basics" | "workSkills" | "education" | "awardsAndCerts";
 
 type HighlightItem = {
   title: string;
@@ -539,10 +539,7 @@ const ResumeProfileCard: React.FC<{
     <div className="rounded-3xl border border-line bg-surface/85 p-6 shadow-sm backdrop-blur">
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-widest text-content-muted">
-            {t("resume.preview")}
-          </p>
-          <h2 className="mt-2 text-2xl font-bold text-content">{profile.name}</h2>
+          <h2 className="text-2xl font-bold text-content">{profile.name}</h2>
           <p className="mt-1 text-sm font-medium text-content-secondary">{profile.targetRole}</p>
         </div>
         <button
@@ -600,16 +597,25 @@ const ResumeProfileCard: React.FC<{
   );
 };
 
+// ── BasicsTab ──────────────────────────────────────────────────────────────────
+const BasicsTab: React.FC<{
+  resumeProfile: ResumeProfileSourceData | null;
+  onOpenPreview: () => void;
+}> = ({ resumeProfile, onOpenPreview }) => {
+  if (!resumeProfile) return null;
+  return (
+    <div className="space-y-8">
+      <ResumeProfileCard profile={resumeProfile} onOpenPreview={onOpenPreview} />
+    </div>
+  );
+};
+
 // ── WorkSkillsTab ──────────────────────────────────────────────────────────────
 const WorkSkillsTab: React.FC<{
   data: ProfileData;
-  resumeProfile: ResumeProfileSourceData | null;
-  onOpenPreview: () => void;
-}> = ({ data, resumeProfile, onOpenPreview }) => {
+}> = ({ data }) => {
   return (
     <div className="space-y-8">
-      {resumeProfile && <ResumeProfileCard profile={resumeProfile} onOpenPreview={onOpenPreview} />}
-
       {/* Skills on top */}
       <div className="rounded-3xl border border-line bg-surface/80 p-6 shadow-sm backdrop-blur">
         <SkillsBlock data={data.skills} />
@@ -753,12 +759,13 @@ const dataPromise = fetch("/data/introduction.json")
 const ProfileSection: React.FC = () => {
   const { t, i18n } = useTranslation("common");
   const navigate = useNavigate();
-  const [activeTab, setActiveTab] = useState<TabId>("workSkills");
+  const [activeTab, setActiveTab] = useState<TabId>("basics");
   const [data, setData] = useState<ProfileData | null>(cachedData);
   const [resumeProfile, setResumeProfile] = useState<ResumeProfileSourceData | null>(null);
   const contentRef = useRef<HTMLDivElement>(null);
 
   const tabs: { id: TabId; labelKey: string }[] = [
+    { id: "basics", labelKey: "profileTabs.basics" },
     { id: "workSkills", labelKey: "profileTabs.workSkills" },
     { id: "education", labelKey: "profileTabs.education" },
     { id: "awardsAndCerts", labelKey: "profileTabs.awardsAndCerts" },
@@ -878,13 +885,13 @@ const ProfileSection: React.FC = () => {
                 animate="show"
                 exit="exit"
               >
-                {activeTab === "workSkills" && (
-                  <WorkSkillsTab
-                    data={data}
+                {activeTab === "basics" && (
+                  <BasicsTab
                     resumeProfile={resumeProfile}
                     onOpenPreview={handleOpenPreview}
                   />
                 )}
+                {activeTab === "workSkills" && <WorkSkillsTab data={data} />}
                 {activeTab === "education" && <EducationTab data={data.education} />}
                 {activeTab === "awardsAndCerts" && (
                   <AwardsAndCertsTab awards={data.awards} certs={data.certificates} />


### PR DESCRIPTION
## Summary
- 프로필 섹션에 `basics` 탭 신설. `ResumeProfileCard`(이름·역할·연락처·인트로·이력서 미리보기 진입 버튼)를 경력/스킬 탭에서 분리해 새 탭으로 이동. `WorkSkillsTab`은 Skills + WorkExperience만 책임지도록 단순화.
- 이력서 미리보기 진입 버튼 라벨을 `resume.preview` ("이력서 미리보기" / "Resume Preview")로 짧게 정리.
- `/resume-preview` 페이지 헤더에서 작은 캡션 제거, `<h1>` 텍스트를 "이력서" / "Resume"로 단축. 페이지에 이미 진입한 시점에서 "이력서 미리보기 열기"는 중복.
- i18n 정리: `profileTabs.basics` ("기본정보" / "Basics") 추가, 사용처 사라진 `resume.openPreview` 키 제거, 헤더용 `resume.heading` ("이력서" / "Resume") 추가.

## Test plan
- [ ] 프로필 진입 시 첫 화면이 `basics` 탭이고 `ResumeProfileCard`가 보임
- [ ] 경력/스킬 탭은 Skills + Work Experience만 보임 (ResumeProfileCard 사라짐)
- [ ] basics 탭의 "이력서 미리보기" 버튼 클릭 시 `/resume-preview`로 이동
- [ ] `/resume-preview` 헤더가 "이력서" 한 줄로 표시되고 위에 캡션 없음
- [ ] 한국어/영어 토글 시 새 라벨 양쪽 정상 노출
- [ ] `Cmd+P` 인쇄 미리보기에서 print 레이아웃 회귀 없음
- [ ] 빌드 성공 (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)