### PR TITLE
Expand AI DevKit skills and make cards collapsible

### DIFF
--- a/public/locales/en/projects.json
+++ b/public/locales/en/projects.json
@@ -21,112 +21,310 @@
           {
             "title": "orchestrator-designer",
             "description": "A skill for designing multi-agent collaboration flows, including decomposition, role assignment, routing, loop control, and merge rules.",
-            "chips": ["Skill Design", "Routing", "Workflow"]
-          }
-        ],
-        "orchestratorTitle": "What the Skill Does",
-        "orchestratorDescription": "Tasks this skill directly designs and decides.",
-        "orchestratorItems": [
-          {
-            "title": "Task Decomposition and Role Assignment",
-            "description": "Breaks a user request into work units and assigns the agent role needed for each stage.",
-            "chips": ["decomposition", "role assignment"]
+            "chips": ["Skill Design", "Routing", "Workflow"],
+            "sections": [
+              {
+                "title": "What the Skill Does",
+                "description": "Tasks this skill directly designs and decides.",
+                "items": [
+                  {
+                    "title": "Task Decomposition and Role Assignment",
+                    "description": "Breaks a user request into work units and assigns the agent role needed for each stage.",
+                    "chips": ["decomposition", "role assignment"]
+                  },
+                  {
+                    "title": "Parallel Result Merge",
+                    "description": "Compares or merges parallel agent outputs and hands them to the next stage.",
+                    "chips": ["parallel", "merge", "handoff"]
+                  },
+                  {
+                    "title": "Loop and Termination Rules",
+                    "description": "Defines where to loop back when output is insufficient and when to terminate the flow.",
+                    "chips": ["loop", "retry", "termination"]
+                  }
+                ]
+              },
+              {
+                "title": "Skill Patterns",
+                "description": "Recurring structural patterns used when applying this skill.",
+                "items": [
+                  {
+                    "title": "Fan-out then Converge",
+                    "description": "Multiple agents process in parallel, then results are gathered back into a single output.",
+                    "chips": ["fan-out", "convergence"]
+                  },
+                  {
+                    "title": "Conditional Routing",
+                    "description": "The next agent depends on the intermediate result.",
+                    "chips": ["routing", "branching"]
+                  },
+                  {
+                    "title": "Feedback Loop",
+                    "description": "Returns to a previous stage and re-runs when the result falls short.",
+                    "chips": ["feedback loop", "retry"]
+                  }
+                ]
+              },
+              {
+                "title": "Skill Principles",
+                "description": "Guidelines for using this skill consistently and safely.",
+                "items": [
+                  {
+                    "title": "Avoid Deep Nesting",
+                    "description": "The main orchestrator owns the full flow instead of stacking deep nested layers.",
+                    "chips": ["main orchestrator", "simple hierarchy"]
+                  },
+                  {
+                    "title": "Define Merge Criteria First",
+                    "description": "Decides what counts as a good result before comparing or merging multiple outputs.",
+                    "chips": ["merge criteria", "evaluation"]
+                  },
+                  {
+                    "title": "Cap Loop Length",
+                    "description": "Pre-sets retry counts and termination conditions to prevent infinite loops.",
+                    "chips": ["loop cap", "termination"]
+                  }
+                ]
+              },
+              {
+                "title": "Skill Outputs",
+                "description": "Core elements left in the final output after this skill runs.",
+                "items": [
+                  {
+                    "title": "Flow Overview",
+                    "description": "Defines the orchestrator overview and stage composition first.",
+                    "chips": ["overview", "premise"]
+                  },
+                  {
+                    "title": "Branch, Loop, and Merge Diagram",
+                    "description": "Visualizes agent relationships, branching, loops, and merges with diagrams.",
+                    "chips": ["Mermaid", "branching", "loop"]
+                  },
+                  {
+                    "title": "Operating Rules",
+                    "description": "Specifies when to hand off, when to retry, how to merge, and when to terminate.",
+                    "chips": ["routing", "merge", "termination"]
+                  }
+                ]
+              }
+            ]
           },
           {
-            "title": "Sequential, Parallel, and Routing Structure",
-            "description": "Determines which stages run sequentially, which run in parallel, and when routing should switch to another agent.",
-            "chips": ["sequential", "parallel", "routing"]
+            "title": "blog-post-mogiyoon",
+            "description": "Turns rough drafts, scattered notes, or topic-only inputs into Velog (velog.io/@mogiyoon) posts. Matches the user's plain-form Korean voice to a chosen category tone (gansal, gochal, debugging, makeismylife) and saves the result as a Markdown file.",
+            "chips": ["Writing", "Style Match", "Markdown"],
+            "sections": [
+              {
+                "title": "What the Skill Does",
+                "description": "Tasks this skill directly designs and decides.",
+                "items": [
+                  {
+                    "title": "Genre Confirmation",
+                    "description": "Confirms one of four categories (gansal, gochal, debugging, makeismylife) by user statement, content inference, or explicit agreement.",
+                    "chips": ["category", "tone"]
+                  },
+                  {
+                    "title": "Topic Extraction",
+                    "description": "Splits broad input into topic candidates and narrows to a single message per post.",
+                    "chips": ["topic", "single message"]
+                  },
+                  {
+                    "title": "Input Shape Detection",
+                    "description": "Chooses the writing mode based on whether the input is a rough draft, a finished-post rewrite, or a topic-only request.",
+                    "chips": ["draft", "rewrite", "from scratch"]
+                  },
+                  {
+                    "title": "Tone and Style Application",
+                    "description": "Reads common-style and the selected category guide, then rewrites the draft in plain-form Korean.",
+                    "chips": ["plain form", "style guide"]
+                  }
+                ]
+              },
+              {
+                "title": "Skill Patterns",
+                "description": "Recurring structural patterns used when applying this skill.",
+                "items": [
+                  {
+                    "title": "Genre → Topic → Input Shape",
+                    "description": "Confirms category, topic, and input shape with the user before writing.",
+                    "chips": ["genre first", "topic", "input"]
+                  },
+                  {
+                    "title": "Primary + Secondary Category",
+                    "description": "When mixing tones, picks one main category and borrows phrasing from the secondary.",
+                    "chips": ["primary", "secondary", "tone mix"]
+                  },
+                  {
+                    "title": "Topic Candidates → Single Pick",
+                    "description": "When multiple topics surface, lists candidates and lets the user choose one.",
+                    "chips": ["candidates", "single pick"]
+                  }
+                ]
+              },
+              {
+                "title": "Skill Principles",
+                "description": "Guidelines for using this skill consistently and safely.",
+                "items": [
+                  {
+                    "title": "Plain-Form Unification",
+                    "description": "Uses ~다 / ~한다 endings and never the formal honorific ~습니다.",
+                    "chips": ["plain form", "no honorifics"]
+                  },
+                  {
+                    "title": "Preserve User Voice",
+                    "description": "Keeps the user's self-deprecating notes and the mix of short and long paragraphs.",
+                    "chips": ["voice", "rhythm"]
+                  },
+                  {
+                    "title": "Self-Check Before Handoff",
+                    "description": "Reviews tone match, paragraph rhythm, and intro/outro naturalness before delivering.",
+                    "chips": ["self-check", "tone match"]
+                  },
+                  {
+                    "title": "Fact-Checking First",
+                    "description": "Never invents the user's experiences and asks for missing information instead.",
+                    "chips": ["no fabrication", "ask user"]
+                  }
+                ]
+              },
+              {
+                "title": "Skill Outputs",
+                "description": "Core elements left in the final output after this skill runs.",
+                "items": [
+                  {
+                    "title": "Markdown File (.md)",
+                    "description": "Saves the result file to a user-specified path or /tmp/.",
+                    "chips": ["markdown", "file"]
+                  },
+                  {
+                    "title": "Filename Convention",
+                    "description": "Saves as {primary_category}-{english-kebab-topic}.md.",
+                    "chips": ["naming", "kebab-case"]
+                  },
+                  {
+                    "title": "One-Line Summary",
+                    "description": "Hands off the core message in one line plus the file path link.",
+                    "chips": ["summary", "handoff"]
+                  }
+                ]
+              }
+            ]
           },
           {
-            "title": "Input Handoff and Merge Logic",
-            "description": "Defines what output becomes the next input and how multiple agent results are compared or merged.",
-            "chips": ["handoff", "merge", "compare"]
-          },
-          {
-            "title": "Loops and Termination Rules",
-            "description": "Controls loop entry, retry rules, fallback paths, and termination conditions so the flow converges cleanly.",
-            "chips": ["loop", "retry", "fallback"]
-          }
-        ],
-        "triggerTitle": "Triggers",
-        "triggerDescription": "Representative conditions that trigger this skill.",
-        "triggerItems": [
-          {
-            "title": "Role-Split Requests",
-            "description": "Triggers when two or more agents with different responsibilities are needed.",
-            "chips": ["2+ agents", "role split"]
-          },
-          {
-            "title": "Collaborative Flow Design",
-            "description": "Covers collaboration, chaining, pipelines, parallel execution, routing, and result integration.",
-            "chips": ["pipeline", "parallel", "integration"]
-          }
-        ],
-        "patternTitle": "Skill Patterns",
-        "patternDescription": "Recurring structural patterns used when applying this skill.",
-        "patternItems": [
-          {
-            "title": "Hierarchical Structure",
-            "description": "A structure with one main orchestrator coordinating specialist sub-agents.",
-            "chips": ["hierarchy", "specialists"]
-          },
-          {
-            "title": "Sequential and Parallel Flow",
-            "description": "Includes sequential pipelines, parallel fan-out, and convergence stages where outputs merge again.",
-            "chips": ["sequential", "fan-out", "convergence"]
-          },
-          {
-            "title": "Conditional Control",
-            "description": "Combines routing conditions, feedback loops, and human checkpoints where needed.",
-            "chips": ["routing", "feedback loop", "human checkpoint"]
-          }
-        ],
-        "principleTitle": "Skill Principles",
-        "principleDescription": "Guidelines for using this skill consistently and safely.",
-        "principleItems": [
-          {
-            "title": "Explicit Context Handoff",
-            "description": "Passes file paths, previous outputs, and evaluation criteria explicitly between stages.",
-            "chips": ["context", "explicit handoff"]
-          },
-          {
-            "title": "Simple Hierarchy",
-            "description": "Keeps the main orchestrator responsible for the full flow instead of building deep nested layers.",
-            "chips": ["main orchestrator", "simple hierarchy"]
-          },
-          {
-            "title": "Role-Based Constraints",
-            "description": "Separates tool and model policies by role and caps iterative loops.",
-            "chips": ["tool policy", "model policy", "loop cap"]
-          },
-          {
-            "title": "Predefined Output Rules",
-            "description": "Defines output formats and termination rules in advance to reduce ambiguity between stages.",
-            "chips": ["output schema", "termination"]
-          }
-        ],
-        "outputTitle": "Skill Outputs",
-        "outputDescription": "Core elements left in the final output after this skill runs.",
-        "outputItems": [
-          {
-            "title": "Overview and Premise",
-            "description": "Defines the orchestrator overview and implementation premise first.",
-            "chips": ["overview", "premise"]
-          },
-          {
-            "title": "Relationship, Branching, and Loop Diagram",
-            "description": "Visualizes agent relationships, branching, and loops with Mermaid diagrams.",
-            "chips": ["Mermaid", "branching", "loop"]
-          },
-          {
-            "title": "Role, I/O, and Handoff Document",
-            "description": "Documents role definitions, inputs and outputs, handoff, retry behavior, and fallback strategy.",
-            "chips": ["roles", "I/O", "handoff"]
-          },
-          {
-            "title": "Operating Rules",
-            "description": "Specifies routing rules, parallel stages, merge logic, and termination conditions at the document level.",
-            "chips": ["routing rules", "merge logic", "termination"]
+            "title": "register-portfolio-project",
+            "description": "Registers a completed external project into the mogiyoon portfolio site. Extracts metadata, gets user confirmation, generates ko/en i18n, auto-detects claudeInfo, copies images, edits the related portfolio files, then forks a feature branch from develop and commits.",
+            "chips": ["Portfolio", "i18n", "Branch / Commit"],
+            "sections": [
+              {
+                "title": "What the Skill Does",
+                "description": "Tasks this skill directly designs and decides.",
+                "items": [
+                  {
+                    "title": "Auto-Extract Project Info",
+                    "description": "Reads package.json, README, git log, and image candidates in parallel to collect metadata.",
+                    "chips": ["package.json", "README", "git log"]
+                  },
+                  {
+                    "title": "claudeInfo Auto-Detection",
+                    "description": "Inspects .claude/agents/, orchestrator traces, and Co-Authored-By patterns to determine method (direct/harness/orchestrator).",
+                    "chips": ["direct", "harness", "orchestrator"]
+                  },
+                  {
+                    "title": "Korean Tone Normalization",
+                    "description": "Unifies endings to ~함 / ~됨 / ~임 and substitutes banned expressions.",
+                    "chips": ["tone normalize", "endings"]
+                  },
+                  {
+                    "title": "ko → en Auto Translation",
+                    "description": "Generates the English i18n once Korean is confirmed, mirroring the same structure.",
+                    "chips": ["i18n", "auto translate"]
+                  },
+                  {
+                    "title": "Portfolio Repo File Generation",
+                    "description": "Writes data, locales, list, card translations, and image assets across six files.",
+                    "chips": ["data", "locales", "images"]
+                  }
+                ]
+              },
+              {
+                "title": "Skill Patterns",
+                "description": "Recurring structural patterns used when applying this skill.",
+                "items": [
+                  {
+                    "title": "Extract → Review → Write → Branch",
+                    "description": "Fixes the order of auto-extract, batch user review, file generation, and branch creation.",
+                    "chips": ["pipeline", "fixed order"]
+                  },
+                  {
+                    "title": "ko First, en Auto-Translated",
+                    "description": "Confirms Korean i18n first, then auto-generates the English version.",
+                    "chips": ["ko first", "auto en"]
+                  },
+                  {
+                    "title": "Batch User Review",
+                    "description": "A single AskUserQuestion call confirms id, subtitle, projectType, techStack, and features at once.",
+                    "chips": ["batch review", "AskUserQuestion"]
+                  }
+                ]
+              },
+              {
+                "title": "Skill Principles",
+                "description": "Guidelines for using this skill consistently and safely.",
+                "items": [
+                  {
+                    "title": "Fork From develop",
+                    "description": "Creates feat/add-{id}, never works on main directly.",
+                    "chips": ["develop", "feat branch"]
+                  },
+                  {
+                    "title": "Safe Automation Boundary",
+                    "description": "pull, push, and PR creation only proceed after explicit user approval.",
+                    "chips": ["pull", "push", "PR"]
+                  },
+                  {
+                    "title": "Source Project Is Read-Only",
+                    "description": "Images are copied, never modified at the source project.",
+                    "chips": ["read-only", "copy only"]
+                  },
+                  {
+                    "title": "Strict Tone Guide",
+                    "description": "Applies CLAUDE.md's ending and banned-expression rules to all Korean text.",
+                    "chips": ["CLAUDE.md", "tone rules"]
+                  }
+                ]
+              },
+              {
+                "title": "Skill Outputs",
+                "description": "Core elements left in the final output after this skill runs.",
+                "items": [
+                  {
+                    "title": "New Data File",
+                    "description": "Creates public/data/projects/{id}.json.",
+                    "chips": ["data", "json"]
+                  },
+                  {
+                    "title": "ko / en i18n",
+                    "description": "Creates public/locales/ko·en/projects/project-{id}.json.",
+                    "chips": ["i18n", "ko", "en"]
+                  },
+                  {
+                    "title": "List and Card Entries",
+                    "description": "Appends entries to projects-list.json and ko/en projects.json.",
+                    "chips": ["list", "card"]
+                  },
+                  {
+                    "title": "Image Assets",
+                    "description": "Copies public/images/{camelCaseProjectName}/Icon, appGif, and overview/* files.",
+                    "chips": ["Icon", "appGif", "overview"]
+                  },
+                  {
+                    "title": "Feature Branch + Commit",
+                    "description": "Forks feat/add-{id} from develop and creates the commit.",
+                    "chips": ["develop", "feat", "commit"]
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/public/locales/ko/projects.json
+++ b/public/locales/ko/projects.json
@@ -21,92 +21,310 @@
           {
             "title": "orchestrator-designer",
             "description": "여러 에이전트가 함께 일할 흐름을 설계하는 스킬입니다. 단계를 나누고, 역할을 정하고, 분기·반복·결과 합치기 규칙을 만듭니다.",
-            "chips": ["Skill Design", "Routing", "Workflow"]
-          }
-        ],
-        "orchestratorTitle": "스킬이 하는 일",
-        "orchestratorDescription": "이 스킬이 맡는 핵심 작업입니다.",
-        "orchestratorItems": [
-          {
-            "title": "요청 분해 및 역할 배정",
-            "description": "하나의 요청을 여러 단계로 나누고, 각 단계에 맞는 에이전트를 붙입니다.",
-            "chips": ["decomposition", "role assignment"]
+            "chips": ["Skill Design", "Routing", "Workflow"],
+            "sections": [
+              {
+                "title": "스킬이 하는 일",
+                "description": "이 스킬이 맡는 핵심 작업입니다.",
+                "items": [
+                  {
+                    "title": "요청 분해 및 역할 배정",
+                    "description": "하나의 요청을 여러 단계로 나누고, 각 단계에 맞는 에이전트를 붙입니다.",
+                    "chips": ["decomposition", "role assignment"]
+                  },
+                  {
+                    "title": "병렬 결과 병합",
+                    "description": "병렬로 돌린 결과를 비교하거나 합쳐서 다음 단계로 넘깁니다.",
+                    "chips": ["parallel", "merge", "handoff"]
+                  },
+                  {
+                    "title": "루프·종료 규칙 정의",
+                    "description": "결과가 부족하면 어디로 돌아갈지와 언제 끝낼지를 정합니다.",
+                    "chips": ["loop", "retry", "termination"]
+                  }
+                ]
+              },
+              {
+                "title": "스킬 적용 패턴",
+                "description": "이 스킬에서 자주 쓰는 작업 흐름입니다.",
+                "items": [
+                  {
+                    "title": "팬아웃 후 수렴",
+                    "description": "여러 에이전트가 나눠 처리한 뒤 결과를 다시 하나로 모읍니다.",
+                    "chips": ["fan-out", "convergence"]
+                  },
+                  {
+                    "title": "조건부 라우팅",
+                    "description": "중간 결과에 따라 다음 에이전트가 달라집니다.",
+                    "chips": ["routing", "branching"]
+                  },
+                  {
+                    "title": "피드백 루프",
+                    "description": "결과가 부족하면 특정 단계로 돌아가 다시 실행합니다.",
+                    "chips": ["feedback loop", "retry"]
+                  }
+                ]
+              },
+              {
+                "title": "스킬 적용 원칙",
+                "description": "이 스킬을 안정적으로 쓰기 위한 기준입니다.",
+                "items": [
+                  {
+                    "title": "깊게 중첩하지 않기",
+                    "description": "메인 오케스트레이터가 전체를 관리하고 구조가 너무 깊어지지 않게 합니다.",
+                    "chips": ["main orchestrator", "simple hierarchy"]
+                  },
+                  {
+                    "title": "병합 기준 먼저 정하기",
+                    "description": "무엇을 좋은 결과로 볼지 먼저 정한 뒤 여러 출력을 비교하거나 합칩니다.",
+                    "chips": ["merge criteria", "evaluation"]
+                  },
+                  {
+                    "title": "루프 끝 정해두기",
+                    "description": "재시도 횟수와 종료 조건을 미리 정해 무한 반복을 막습니다.",
+                    "chips": ["loop cap", "termination"]
+                  }
+                ]
+              },
+              {
+                "title": "스킬 산출물",
+                "description": "이 스킬 실행 후 결과물에 남는 핵심 항목입니다.",
+                "items": [
+                  {
+                    "title": "흐름 개요",
+                    "description": "전체 단계와 역할 구성을 먼저 정리합니다.",
+                    "chips": ["overview", "premise"]
+                  },
+                  {
+                    "title": "분기·루프·병합 그림",
+                    "description": "에이전트 관계, 분기, 루프, 병합 구조를 다이어그램으로 보여줍니다.",
+                    "chips": ["Mermaid", "branching", "loop"]
+                  },
+                  {
+                    "title": "운영 규칙",
+                    "description": "언제 넘기고, 언제 다시 돌리고, 어떻게 합치고, 언제 끝낼지를 정리합니다.",
+                    "chips": ["routing", "merge", "termination"]
+                  }
+                ]
+              }
+            ]
           },
           {
-            "title": "병렬 결과 병합",
-            "description": "병렬로 돌린 결과를 비교하거나 합쳐서 다음 단계로 넘깁니다.",
-            "chips": ["parallel", "merge", "handoff"]
+            "title": "blog-post-mogiyoon",
+            "description": "메모, 초고, 주제만 있는 입력을 벨로그(velog.io/@mogiyoon)에 올라가는 글로 정리하는 스킬임. 카테고리 톤(간살/고찰/디버깅/makeismylife)과 사용자 평어체 어투를 맞춰 마크다운 파일로 산출함.",
+            "chips": ["Writing", "Style Match", "Markdown"],
+            "sections": [
+              {
+                "title": "스킬이 하는 일",
+                "description": "이 스킬이 맡는 핵심 작업입니다.",
+                "items": [
+                  {
+                    "title": "장르 확정",
+                    "description": "간살, 고찰, 디버깅, makeismylife 중 하나를 사용자 명시·내용 추론·합의로 확정합니다.",
+                    "chips": ["category", "tone"]
+                  },
+                  {
+                    "title": "주제 추출",
+                    "description": "광범위한 입력에서 주제 후보를 분리하고 한 글 한 주제 원칙으로 좁힙니다.",
+                    "chips": ["topic", "single message"]
+                  },
+                  {
+                    "title": "입력 형태 판별",
+                    "description": "거친 메모, 완성된 글 리라이트, 주제만 던진 경우에 맞춰 작성 모드를 결정합니다.",
+                    "chips": ["draft", "rewrite", "from scratch"]
+                  },
+                  {
+                    "title": "톤·스타일 적용",
+                    "description": "common-style과 카테고리 가이드를 읽어 평어체로 다듬습니다.",
+                    "chips": ["plain form", "style guide"]
+                  }
+                ]
+              },
+              {
+                "title": "스킬 적용 패턴",
+                "description": "이 스킬에서 자주 쓰는 작업 흐름입니다.",
+                "items": [
+                  {
+                    "title": "장르 → 주제 → 입력 형태",
+                    "description": "글을 쓰기 전에 카테고리, 주제, 입력 형태를 차례대로 확정합니다.",
+                    "chips": ["genre first", "topic", "input"]
+                  },
+                  {
+                    "title": "주 카테고리 + 보조 카테고리",
+                    "description": "톤을 섞을 경우 한쪽을 메인으로 잡고 다른 쪽에서 톤만 빌립니다.",
+                    "chips": ["primary", "secondary", "tone mix"]
+                  },
+                  {
+                    "title": "주제 후보 제시 후 단일 선택",
+                    "description": "여러 주제가 보이면 후보를 제시한 뒤 사용자가 하나를 선택하게 합니다.",
+                    "chips": ["candidates", "single pick"]
+                  }
+                ]
+              },
+              {
+                "title": "스킬 적용 원칙",
+                "description": "이 스킬을 안정적으로 쓰기 위한 기준입니다.",
+                "items": [
+                  {
+                    "title": "평어체 통일",
+                    "description": "~다 / ~한다 종결로 통일하고 격식체(~습니다)는 사용하지 않습니다.",
+                    "chips": ["plain form", "no honorifics"]
+                  },
+                  {
+                    "title": "사용자 톤 보존",
+                    "description": "사용자 특유의 자조·유머와 짧은 문단·긴 문단의 혼합을 유지합니다.",
+                    "chips": ["voice", "rhythm"]
+                  },
+                  {
+                    "title": "자기 검증 후 전달",
+                    "description": "카테고리 톤, 문단 호흡, 도입·마무리 인위성 여부를 점검한 뒤 전달합니다.",
+                    "chips": ["self-check", "tone match"]
+                  },
+                  {
+                    "title": "사실 확인 우선",
+                    "description": "사용자가 안 한 경험을 지어내지 않고 부족한 정보는 사용자에게 묻습니다.",
+                    "chips": ["no fabrication", "ask user"]
+                  }
+                ]
+              },
+              {
+                "title": "스킬 산출물",
+                "description": "이 스킬 실행 후 결과물에 남는 핵심 항목입니다.",
+                "items": [
+                  {
+                    "title": "마크다운 파일(.md)",
+                    "description": "사용자 지정 경로 또는 /tmp/에 결과 파일을 저장합니다.",
+                    "chips": ["markdown", "file"]
+                  },
+                  {
+                    "title": "파일명 규칙 적용",
+                    "description": "{주_카테고리}-{영문 kebab-case 주제}.md 형식으로 저장합니다.",
+                    "chips": ["naming", "kebab-case"]
+                  },
+                  {
+                    "title": "한 줄 요약",
+                    "description": "글의 핵심 메시지 한 줄과 파일 경로 링크를 함께 전달합니다.",
+                    "chips": ["summary", "handoff"]
+                  }
+                ]
+              }
+            ]
           },
           {
-            "title": "루프·종료 규칙 정의",
-            "description": "결과가 부족하면 어디로 돌아갈지와 언제 끝낼지를 정합니다.",
-            "chips": ["loop", "retry", "termination"]
-          }
-        ],
-        "triggerTitle": "스킬 실행 트리거",
-        "triggerDescription": "이 스킬을 쓰면 좋은 대표 상황입니다.",
-        "triggerItems": [
-          {
-            "title": "한 번에 끝나지 않는 작업",
-            "description": "역할이 다른 에이전트가 둘 이상 필요하고, 중간 결과를 넘기거나 합쳐야 하는 흐름에서 사용합니다.",
-            "chips": ["2+ agents", "multi-step"]
-          }
-        ],
-        "patternTitle": "스킬 적용 패턴",
-        "patternDescription": "이 스킬에서 자주 쓰는 작업 흐름입니다.",
-        "patternItems": [
-          {
-            "title": "팬아웃 후 수렴",
-            "description": "여러 에이전트가 나눠 처리한 뒤 결과를 다시 하나로 모읍니다.",
-            "chips": ["fan-out", "convergence"]
-          },
-          {
-            "title": "조건부 라우팅",
-            "description": "중간 결과에 따라 다음 에이전트가 달라집니다.",
-            "chips": ["routing", "branching"]
-          },
-          {
-            "title": "피드백 루프",
-            "description": "결과가 부족하면 특정 단계로 돌아가 다시 실행합니다.",
-            "chips": ["feedback loop", "retry"]
-          }
-        ],
-        "principleTitle": "스킬 적용 원칙",
-        "principleDescription": "이 스킬을 안정적으로 쓰기 위한 기준입니다.",
-        "principleItems": [
-          {
-            "title": "깊게 중첩하지 않기",
-            "description": "메인 오케스트레이터가 전체를 관리하고 구조가 너무 깊어지지 않게 합니다.",
-            "chips": ["main orchestrator", "simple hierarchy"]
-          },
-          {
-            "title": "병합 기준 먼저 정하기",
-            "description": "무엇을 좋은 결과로 볼지 먼저 정한 뒤 여러 출력을 비교하거나 합칩니다.",
-            "chips": ["merge criteria", "evaluation"]
-          },
-          {
-            "title": "루프 끝 정해두기",
-            "description": "재시도 횟수와 종료 조건을 미리 정해 무한 반복을 막습니다.",
-            "chips": ["loop cap", "termination"]
-          }
-        ],
-        "outputTitle": "스킬 산출물",
-        "outputDescription": "이 스킬 실행 후 결과물에 남는 핵심 항목입니다.",
-        "outputItems": [
-          {
-            "title": "흐름 개요",
-            "description": "전체 단계와 역할 구성을 먼저 정리합니다.",
-            "chips": ["overview", "premise"]
-          },
-          {
-            "title": "분기·루프·병합 그림",
-            "description": "에이전트 관계, 분기, 루프, 병합 구조를 다이어그램으로 보여줍니다.",
-            "chips": ["Mermaid", "branching", "loop"]
-          },
-          {
-            "title": "운영 규칙",
-            "description": "언제 넘기고, 언제 다시 돌리고, 어떻게 합치고, 언제 끝낼지를 정리합니다.",
-            "chips": ["routing", "merge", "termination"]
+            "title": "register-portfolio-project",
+            "description": "외부 작업 디렉토리의 완성된 프로젝트를 mogiyoon 포트폴리오 사이트에 자동 등록하는 스킬임. 정보 추출 → 사용자 검토 → ko/en i18n 생성 → claudeInfo 자동 감지 → 이미지 복사 → 포트폴리오 레포 파일 생성 → develop 브랜치에서 분기·커밋 순으로 진행함.",
+            "chips": ["Portfolio", "i18n", "Branch / Commit"],
+            "sections": [
+              {
+                "title": "스킬이 하는 일",
+                "description": "이 스킬이 맡는 핵심 작업입니다.",
+                "items": [
+                  {
+                    "title": "정보 자동 추출",
+                    "description": "package.json, README, git log, 이미지 후보를 병렬로 읽어 프로젝트 메타데이터를 수집합니다.",
+                    "chips": ["package.json", "README", "git log"]
+                  },
+                  {
+                    "title": "claudeInfo 자동 감지",
+                    "description": ".claude/agents/, orchestrator 흔적, Co-Authored-By 패턴으로 method(direct/harness/orchestrator)를 결정합니다.",
+                    "chips": ["direct", "harness", "orchestrator"]
+                  },
+                  {
+                    "title": "한국어 어투 정규화",
+                    "description": "~함 / ~됨 / ~임 종결로 통일하고 금지 표현을 치환합니다.",
+                    "chips": ["tone normalize", "endings"]
+                  },
+                  {
+                    "title": "ko → en 자동 번역",
+                    "description": "한국어 i18n이 확정되면 동일 구조로 영문 i18n을 생성합니다.",
+                    "chips": ["i18n", "auto translate"]
+                  },
+                  {
+                    "title": "포트폴리오 레포 파일 생성",
+                    "description": "data, locales, list, 카드 번역, 이미지 6종 파일을 모두 처리합니다.",
+                    "chips": ["data", "locales", "images"]
+                  }
+                ]
+              },
+              {
+                "title": "스킬 적용 패턴",
+                "description": "이 스킬에서 자주 쓰는 작업 흐름입니다.",
+                "items": [
+                  {
+                    "title": "추출 → 검토 → 작성 → 분기",
+                    "description": "자동 추출, 사용자 일괄 검토, 파일 작성, 브랜치 분기 순서를 고정합니다.",
+                    "chips": ["pipeline", "fixed order"]
+                  },
+                  {
+                    "title": "ko 우선, en 자동 번역",
+                    "description": "한국어 i18n을 먼저 확정한 뒤 영어 i18n을 자동 생성합니다.",
+                    "chips": ["ko first", "auto en"]
+                  },
+                  {
+                    "title": "일괄 사용자 검토",
+                    "description": "AskUserQuestion 단일 호출로 id, subtitle, projectType, techStack, features를 한 번에 확인합니다.",
+                    "chips": ["batch review", "AskUserQuestion"]
+                  }
+                ]
+              },
+              {
+                "title": "스킬 적용 원칙",
+                "description": "이 스킬을 안정적으로 쓰기 위한 기준입니다.",
+                "items": [
+                  {
+                    "title": "develop 브랜치에서 분기",
+                    "description": "feat/add-{id} 형태로 새 브랜치를 만들고 main 브랜치에서 직접 작업하지 않습니다.",
+                    "chips": ["develop", "feat branch"]
+                  },
+                  {
+                    "title": "안전 자동화 경계",
+                    "description": "pull, push, PR 생성은 사용자 명시적 승인 후에만 수행합니다.",
+                    "chips": ["pull", "push", "PR"]
+                  },
+                  {
+                    "title": "소스 프로젝트는 읽기 전용",
+                    "description": "이미지조차 복사만 하고 원본 파일은 수정하지 않습니다.",
+                    "chips": ["read-only", "copy only"]
+                  },
+                  {
+                    "title": "어투 가이드 엄격 준수",
+                    "description": "CLAUDE.md의 종결 어미와 금지 표현 규칙을 한국어 텍스트에 그대로 적용합니다.",
+                    "chips": ["CLAUDE.md", "tone rules"]
+                  }
+                ]
+              },
+              {
+                "title": "스킬 산출물",
+                "description": "이 스킬 실행 후 결과물에 남는 핵심 항목입니다.",
+                "items": [
+                  {
+                    "title": "신규 데이터 파일",
+                    "description": "public/data/projects/{id}.json 파일을 새로 작성합니다.",
+                    "chips": ["data", "json"]
+                  },
+                  {
+                    "title": "ko / en i18n",
+                    "description": "public/locales/ko·en/projects/project-{id}.json 두 파일을 생성합니다.",
+                    "chips": ["i18n", "ko", "en"]
+                  },
+                  {
+                    "title": "목록·카드 등록",
+                    "description": "projects-list.json과 ko/en projects.json에 새 항목을 추가합니다.",
+                    "chips": ["list", "card"]
+                  },
+                  {
+                    "title": "이미지 자산",
+                    "description": "public/images/{camelCaseProjectName}/Icon, appGif, overview/* 파일을 복사합니다.",
+                    "chips": ["Icon", "appGif", "overview"]
+                  },
+                  {
+                    "title": "feature 브랜치 + 커밋",
+                    "description": "develop 브랜치에서 feat/add-{id}로 분기 후 커밋을 생성합니다.",
+                    "chips": ["develop", "feat", "commit"]
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/src/components/AiDevKitModal/DetailItems.tsx
+++ b/src/components/AiDevKitModal/DetailItems.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import FlowDiagram from './FlowDiagram';
-import { DetailIcon, GroupIcon } from './icons';
+import { ChevronIcon, DetailIcon, GroupIcon } from './icons';
 import type {
   AiDevKitCodeSample,
   AiDevKitDetailGroup,
@@ -152,14 +152,23 @@ const DiagramItems: React.FC<DetailItemsProps> = ({ section }) => (
   </div>
 );
 
-const FlowItems: React.FC<DetailItemsProps> = ({ section }) => (
-  <div className="space-y-4">
-    {section.items?.map((detailItem) => (
-      <article
-        key={`${section.title}-${detailItem.title}`}
-        className="rounded-card border border-line/70 bg-surface p-5 shadow-sm"
+const FlowItemCard: React.FC<{
+  sectionTitle: string;
+  detailItem: AiDevKitDetailItem;
+}> = ({ sectionTitle, detailItem }) => {
+  const [expanded, setExpanded] = useState(false);
+  const contentId = `flow-content-${sectionTitle}-${detailItem.title}`.replace(/\s+/g, '-');
+
+  return (
+    <article className="rounded-card border border-line/70 bg-surface shadow-sm">
+      <button
+        type="button"
+        onClick={() => setExpanded((prev) => !prev)}
+        aria-expanded={expanded}
+        aria-controls={contentId}
+        className="flex w-full items-start justify-between gap-4 rounded-card p-5 text-left transition-colors hover:bg-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500"
       >
-        <div className="mb-5">
+        <div className="min-w-0">
           <div className="inline-flex items-center rounded-full border border-line bg-content px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-surface shadow-sm">
             Harness Run
           </div>
@@ -172,17 +181,36 @@ const FlowItems: React.FC<DetailItemsProps> = ({ section }) => (
             </p>
           )}
         </div>
+        <span className="mt-1 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-accent-50 text-accent-700">
+          <ChevronIcon expanded={expanded} />
+        </span>
+      </button>
 
-        <FlowDiagram
-          idBase={`${section.title}-${detailItem.title}`}
-          steps={detailItem.steps ?? []}
-          loops={detailItem.loops ?? []}
-          stepDetails={detailItem.stepDetails ?? []}
-        />
+      {expanded && (
+        <div id={contentId} className="border-t border-line/70 px-5 pb-5 pt-4">
+          <FlowDiagram
+            idBase={`${sectionTitle}-${detailItem.title}`}
+            steps={detailItem.steps ?? []}
+            loops={detailItem.loops ?? []}
+            stepDetails={detailItem.stepDetails ?? []}
+          />
 
-        <DetailGroupGrid itemTitle={detailItem.title} groups={detailItem.groups} />
-        <CodeSamples itemTitle={detailItem.title} samples={detailItem.samples} />
-      </article>
+          <DetailGroupGrid itemTitle={detailItem.title} groups={detailItem.groups} />
+          <CodeSamples itemTitle={detailItem.title} samples={detailItem.samples} />
+        </div>
+      )}
+    </article>
+  );
+};
+
+const FlowItems: React.FC<DetailItemsProps> = ({ section }) => (
+  <div className="space-y-4">
+    {section.items?.map((detailItem) => (
+      <FlowItemCard
+        key={`${section.title}-${detailItem.title}`}
+        sectionTitle={section.title}
+        detailItem={detailItem}
+      />
     ))}
   </div>
 );

--- a/src/components/AiDevKitModal/SkillGroups.tsx
+++ b/src/components/AiDevKitModal/SkillGroups.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { InlineArrowIcon } from './icons';
+import React, { useState } from 'react';
+import { ChevronIcon, InlineArrowIcon } from './icons';
 import type {
   AiDevKitDetailItem,
   AiDevKitDetailSection,
@@ -368,10 +368,19 @@ const SkillSectionCard: React.FC<{
 
 const SkillItemCard: React.FC<{ skillItem: AiDevKitSkillItem }> = ({
   skillItem,
-}) => (
-  <article className="rounded-card border border-line/70 bg-surface p-5 shadow-sm">
-    <div className="flex flex-col gap-4">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+}) => {
+  const [expanded, setExpanded] = useState(false);
+  const contentId = `skill-content-${skillItem.title.replace(/\s+/g, '-')}`;
+
+  return (
+    <article className="rounded-card border border-line/70 bg-surface shadow-sm">
+      <button
+        type="button"
+        onClick={() => setExpanded((prev) => !prev)}
+        aria-expanded={expanded}
+        aria-controls={contentId}
+        className="flex w-full items-start justify-between gap-4 rounded-card p-5 text-left transition-colors hover:bg-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500"
+      >
         <div className="max-w-3xl">
           <h5 className="text-lg font-bold text-content-strong">
             {skillItem.title}
@@ -382,22 +391,29 @@ const SkillItemCard: React.FC<{ skillItem: AiDevKitSkillItem }> = ({
             </p>
           )}
         </div>
-      </div>
+        <span className="mt-1 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-accent-50 text-accent-700">
+          <ChevronIcon expanded={expanded} />
+        </span>
+      </button>
 
-      <SkillModuleDiagram skillItem={skillItem} />
+      {expanded && (
+        <div id={contentId} className="flex flex-col gap-4 border-t border-line/70 px-5 pb-5 pt-4">
+          <SkillModuleDiagram skillItem={skillItem} />
 
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-        {skillItem.sections.map((groupSection, index) => (
-          <SkillSectionCard
-            key={`${skillItem.title}-${groupSection.title}`}
-            section={groupSection}
-            index={index}
-          />
-        ))}
-      </div>
-    </div>
-  </article>
-);
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            {skillItem.sections.map((groupSection, index) => (
+              <SkillSectionCard
+                key={`${skillItem.title}-${groupSection.title}`}
+                section={groupSection}
+                index={index}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </article>
+  );
+};
 
 const SkillGroups: React.FC<SkillGroupsProps> = ({ section }) => {
   if (section.layout !== 'skill-groups' || !section.skillItems?.length) {

--- a/src/components/AiDevKitModal/icons.tsx
+++ b/src/components/AiDevKitModal/icons.tsx
@@ -91,6 +91,23 @@ export const CloseIcon: React.FC = () => (
   </svg>
 );
 
+export const ChevronIcon: React.FC<{ expanded: boolean }> = ({ expanded }) => (
+  <svg
+    className={`h-4 w-4 shrink-0 transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}
+    viewBox="0 0 16 16"
+    fill="none"
+    aria-hidden="true"
+  >
+    <path
+      d="M4 6L8 10L12 6"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
 export const InlineArrowIcon: React.FC = () => (
   <svg
     className="mx-1 h-4 w-4 text-accent-500"

--- a/src/sections/home/ProjectsSection.tsx
+++ b/src/sections/home/ProjectsSection.tsx
@@ -73,26 +73,10 @@ const ProjectsSection: React.FC = () => {
         }
     };
 
-    const skillsCardItems = t('aiDevKit.skills.detail.cardItems', {
+    const skillItems = t('aiDevKit.skills.detail.cardItems', {
         ns: 'projects',
         returnObjects: true,
-    }) as AiDevKitDetailItem[];
-    const skillsOrchestratorItems = t('aiDevKit.skills.detail.orchestratorItems', {
-        ns: 'projects',
-        returnObjects: true,
-    }) as AiDevKitDetailItem[];
-    const skillsPatternItems = t('aiDevKit.skills.detail.patternItems', {
-        ns: 'projects',
-        returnObjects: true,
-    }) as AiDevKitDetailItem[];
-    const skillsPrincipleItems = t('aiDevKit.skills.detail.principleItems', {
-        ns: 'projects',
-        returnObjects: true,
-    }) as AiDevKitDetailItem[];
-    const skillsOutputItems = t('aiDevKit.skills.detail.outputItems', {
-        ns: 'projects',
-        returnObjects: true,
-    }) as AiDevKitDetailItem[];
+    }) as AiDevKitSkillItem[];
     const mcpServersItems = t('aiDevKit.mcp.detail.serversItems', {
         ns: 'projects',
         returnObjects: true,
@@ -107,34 +91,6 @@ const ProjectsSection: React.FC = () => {
     }) as AiDevKitDetailItem[];
 
     const closeLabel = t('aiDevKit.modal.close', { ns: 'projects' });
-
-    const skillItems: AiDevKitSkillItem[] = skillsCardItems.map((skillItem) => ({
-        title: skillItem.title,
-        description: skillItem.description,
-        chips: skillItem.chips,
-        sections: [
-            {
-                title: t('aiDevKit.skills.detail.orchestratorTitle', { ns: 'projects' }),
-                description: t('aiDevKit.skills.detail.orchestratorDescription', { ns: 'projects' }),
-                items: skillsOrchestratorItems,
-            },
-            {
-                title: t('aiDevKit.skills.detail.patternTitle', { ns: 'projects' }),
-                description: t('aiDevKit.skills.detail.patternDescription', { ns: 'projects' }),
-                items: skillsPatternItems,
-            },
-            {
-                title: t('aiDevKit.skills.detail.principleTitle', { ns: 'projects' }),
-                description: t('aiDevKit.skills.detail.principleDescription', { ns: 'projects' }),
-                items: skillsPrincipleItems,
-            },
-            {
-                title: t('aiDevKit.skills.detail.outputTitle', { ns: 'projects' }),
-                description: t('aiDevKit.skills.detail.outputDescription', { ns: 'projects' }),
-                items: skillsOutputItems,
-            },
-        ],
-    }));
 
     const devKitItems: DevKitCardData[] = [
         {


### PR DESCRIPTION
## Summary
- Restructure the AI DevKit skill modal i18n so each skill carries its own \`sections\` array instead of sharing one set of orchestrator/pattern/principle/output keys. Add \`blog-post-mogiyoon\` and \`register-portfolio-project\` alongside the existing \`orchestrator-designer\` entry, with ko/en copy.
- Make every skill card and harness card collapsible. Header (label, title, description, chevron) stays visible; the diagram, sections, and groups expand on click. Default collapsed; \`aria-expanded\` / \`aria-controls\` / focus ring on the toggle.

## Test plan
- [x] \`npx tsc -b\` clean
- [x] \`npm test\` — 11 resume tests still green after merging develop
- [ ] Manual: open the AI DevKit modal, expand each of the 3 skill cards and 5 harness cards, confirm content renders the same as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)