### PR TITLE
Redesign projects section with sticky sidebar and flip preview

### DIFF
--- a/public/locales/en/projects.json
+++ b/public/locales/en/projects.json
@@ -1,6 +1,10 @@
 {
   "projectTitle": "Projects",
   "projectSubtitle": "",
+  "projectPreview": {
+    "label": "Preview Card",
+    "hint": "Flips every 2 seconds."
+  },
   "preparingProjectSubtitle": "Projects currently in progress",
   "aiDevKit": {
     "title": "AI DevKit",

--- a/public/locales/ko/projects.json
+++ b/public/locales/ko/projects.json
@@ -1,6 +1,10 @@
 {
   "projectTitle": "프로젝트",
   "projectSubtitle": "",
+  "projectPreview": {
+    "label": "예시 카드",
+    "hint": "2초마다 앞뒤로 회전합니다."
+  },
   "preparingProjectSubtitle": "현재 준비 중인 프로젝트들",
   "aiDevKit": {
     "title": "AI DevKit",

--- a/src/components/AiDevKitCard/index.tsx
+++ b/src/components/AiDevKitCard/index.tsx
@@ -5,11 +5,11 @@ import { animation } from '../../design-tokens';
 interface AiDevKitCardProps {
     icon: React.ReactNode;
     title: string;
-    description: string;
+    description?: string;
     onClick: () => void;
 }
 
-const AiDevKitCard: React.FC<AiDevKitCardProps> = ({ icon, title, description, onClick }) => {
+const AiDevKitCard: React.FC<AiDevKitCardProps> = ({ icon, title, onClick }) => {
     return (
         <motion.button
             type="button"
@@ -20,27 +20,25 @@ const AiDevKitCard: React.FC<AiDevKitCardProps> = ({ icon, title, description, o
                 flex h-full w-full flex-col overflow-hidden text-left
                 bg-surface rounded-card shadow-sm
                 hover:shadow-xl transition-shadow duration-300
-                cursor-pointer
+                cursor-pointer justify-center items-center
             "
         >
-            <div className="p-4">
-                <div className="flex aspect-[4/3] items-center justify-center rounded-[2rem] bg-surface-subtle">
-                    <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-accent-50 text-accent-600 shadow-sm">
+            <div className="p-3">
+                <div className="flex aspect-[16/10] items-center justify-center rounded-[1.5rem] bg-surface-subtle">
+                    <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-accent-50 text-accent-600 shadow-sm">
                         {icon}
                     </div>
                 </div>
             </div>
 
-            <div className="flex flex-1 flex-col px-5 pb-5">
+            <div className="flex flex-1 flex-col px-4 pb-4">
                 <div className="flex items-start gap-3">
                     <div className="min-w-0 flex-1">
-                        <h4 className="text-base font-bold text-content">{title}</h4>
+                        <h4 className="line-clamp-2 min-h-[2.5rem] text-sm font-bold leading-tight text-content sm:min-h-[2.75rem] sm:text-[0.95rem]">
+                            {title}
+                        </h4>
                     </div>
-                    <svg xmlns="http://www.w3.org/2000/svg" className="mt-1 h-4 w-4 shrink-0 text-content-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                    </svg>
                 </div>
-                <p className="mt-2 text-sm leading-relaxed text-content-secondary line-clamp-3">{description}</p>
             </div>
         </motion.button>
     );

--- a/src/components/PortfolioCard/index.tsx
+++ b/src/components/PortfolioCard/index.tsx
@@ -1,76 +1,95 @@
-import React, { useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import type { ProjectSummary } from '../../types';
+import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { ProjectSummary } from "../../types";
 
 interface PortfolioCardProps {
-    project: ProjectSummary;
-    className?: string;
-    onClick: () => void;
+  project: ProjectSummary;
+  className?: string;
+  onClick: () => void;
 }
 
-const PortfolioCard: React.FC<PortfolioCardProps> = ({ project, className, onClick }) => {
-    const { t } = useTranslation('projects');
+const PortfolioCard: React.FC<PortfolioCardProps> = ({
+  project,
+  className,
+  onClick,
+}) => {
+  const { t } = useTranslation("projects");
 
-    // 1. 카드의 뒤집힘 상태를 관리하기 위한 state 추가
-    const [isFlipped, setIsFlipped] = useState(false);
+  // 1. 카드의 뒤집힘 상태를 관리하기 위한 state 추가
+  const [isFlipped, setIsFlipped] = useState(false);
 
-    const handleImageError = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
-        e.currentTarget.onerror = null;
-        e.currentTarget.src = "https://placehold.co/300x200/cccccc/333333?text=Image+Not+Found";
-    };
+  const handleImageError = (
+    e: React.SyntheticEvent<HTMLImageElement, Event>,
+  ) => {
+    e.currentTarget.onerror = null;
+    e.currentTarget.src =
+      "https://placehold.co/300x200/cccccc/333333?text=Image+Not+Found";
+  };
 
-    const handleCardClick = () => {
-        onClick();
-        setIsFlipped(false);
-    }
+  const handleCardClick = () => {
+    onClick();
+    setIsFlipped(false);
+  };
 
-    return (
-        <div onClick={handleCardClick} className={`block cursor-pointer ${className || ''}`}>
-            {/* 3D 효과를 위한 perspective 컨테이너 */}
-            <div
-                className="w-full aspect-[9/16]"
-                style={{ perspective: '1000px' }}
-                onMouseEnter={() => setIsFlipped(true)}
-                onMouseLeave={() => setIsFlipped(false)}
-            >
-                <div
-                    className="relative w-full h-full transition-transform duration-700"
-                    style={{
-                        transformStyle: 'preserve-3d',
-                        transform: isFlipped ? 'rotateY(180deg)' : 'rotateY(0deg)',
-                    }}
+  return (
+    <div
+      onClick={handleCardClick}
+      className={`block cursor-pointer ${className || ""}`}
+    >
+      {/* 3D 효과를 위한 perspective 컨테이너 */}
+      <div
+        className="w-full aspect-[24/41]"
+        style={{ perspective: "1000px" }}
+        onMouseEnter={() => setIsFlipped(true)}
+        onMouseLeave={() => setIsFlipped(false)}
+      >
+        <div
+          className="relative w-full h-full transition-transform duration-700"
+          style={{
+            transformStyle: "preserve-3d",
+            transform: isFlipped ? "rotateY(180deg)" : "rotateY(0deg)",
+          }}
+        >
+          <div
+            className="absolute w-full h-full"
+            style={{ backfaceVisibility: "hidden" }}
+          >
+            <div className="bg-surface rounded-card shadow-lg hover:shadow-xl transition-shadow duration-300 overflow-hidden flex flex-col h-full">
+              <div className="p-3 sm:p-4">
+                <img
+                  src={
+                    project.screenshots.length > 0
+                      ? project.screenshots[0].src
+                      : "https://placehold.co/300x300/cccccc/333333?text=Project+Image"
+                  }
+                  alt={`${t(project.title || "")} Thumbnail`}
+                  className="w-full aspect-square object-contain rounded-[3rem]"
+                  onError={handleImageError}
+                />
+              </div>
+              <div className="px-5 pb-4 flex flex-col flex-grow overflow-y-auto sm:px-6">
+                <h3 className="mb-2 truncate text-lg font-bold leading-snug sm:text-[1.35rem]">
+                  {t(project.title || "")}
+                </h3>
+                <p
+                  className="
+                                mb-2 min-h-[3.3rem]
+                                text-sm leading-relaxed text-content-secondary
+                                line-clamp-2
+                                sm:min-h-[3.8rem] sm:text-[0.95rem]
+                            "
                 >
-                    <div className="absolute w-full h-full" style={{ backfaceVisibility: 'hidden' }}>
-                        <div className="bg-surface rounded-card shadow-lg hover:shadow-xl transition-shadow duration-300 overflow-hidden flex flex-col h-full">
-                            <div className="p-4">
-                                <img
-                                    src={project.screenshots.length > 0 ? project.screenshots[0].src : "https://placehold.co/300x300/cccccc/333333?text=Project+Image"}
-                                    alt={`${t(project.title || '')} Thumbnail`}
-                                    className="w-full aspect-square object-contain rounded-[3rem]"
-                                    onError={handleImageError}
-                                />
-                            </div>
-                        <div className="px-6 pb-4 flex flex-col flex-grow overflow-y-auto">
-                            <h3 className="text-2xl font-bold mb-2 truncate">
-                                {t(project.title || '')}
-                            </h3>
-                            <p className="
-                                text-content-secondary mb-2
-                                text-sm h-10
-                                md:text-base md:h-20
-                                line-clamp-3
-                            ">
-                                {t(project.subtitle || '')}
-                            </p>
-                            <div className="flex flex-wrap mt-auto">
-                                <span className="bg-accent-100 text-accent-700 text-xs font-medium px-2 py-0.5 rounded-full">
-                                    {t(project.projectType || '')}
-                                </span>
-                            </div>
-                        </div>
-                            {project.claudeInfo && (
-                                <div
-                                    className="
+                  {t(project.subtitle || "")}
+                </p>
+                <div className="flex flex-wrap mt-auto">
+                  <span className="bg-accent-100 text-accent-700 text-xs font-medium px-2 py-0.5 rounded-full">
+                    {t(project.projectType || "")}
+                  </span>
+                </div>
+              </div>
+              {project.claudeInfo && (
+                <div
+                  className="
                                         pointer-events-none select-none
                                         absolute top-3 right-3
                                         flex items-center gap-1.5
@@ -81,28 +100,35 @@ const PortfolioCard: React.FC<PortfolioCardProps> = ({ project, className, onCli
                                         backdrop-blur-md
                                         shadow-[0_0_12px_rgba(99,102,241,0.3),inset_0_1px_0_rgba(255,255,255,0.4)]
                                     "
-                                    aria-hidden
-                                >
-                                    {/* sparkle icon */}
-                                    <svg className="w-3.5 h-3.5 shrink-0 drop-shadow-[0_0_2px_rgba(99,102,241,0.6)]" viewBox="0 0 24 24" fill="none">
-                                        <path d="M12 2L13.5 9.5L20 8L14.5 12L20 16L13.5 14.5L12 22L10.5 14.5L4 16L9.5 12L4 8L10.5 9.5L12 2Z" fill="white" />
-                                    </svg>
-                                    <span
-                                        className="
+                  aria-hidden
+                >
+                  {/* sparkle icon */}
+                  <svg
+                    className="w-3.5 h-3.5 shrink-0 drop-shadow-[0_0_2px_rgba(99,102,241,0.6)]"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                  >
+                    <path
+                      d="M12 2L13.5 9.5L20 8L14.5 12L20 16L13.5 14.5L12 22L10.5 14.5L4 16L9.5 12L4 8L10.5 9.5L12 2Z"
+                      fill="white"
+                    />
+                  </svg>
+                  <span
+                    className="
                                             text-[10px] font-bold tracking-wide
                                             bg-gradient-to-r from-indigo-600 via-violet-500 to-indigo-500
                                             bg-clip-text text-transparent
                                         "
-                                    >
-                                        Vibe
-                                    </span>
-                                    {/* secondary sparkle dot */}
-                                    <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-white shadow-[0_0_3px_rgba(99,102,241,0.5)]" />
-                                </div>
-                            )}
-                            {project.stickerText && (
-                                <div
-                                className={`
+                  >
+                    Vibe
+                  </span>
+                  {/* secondary sparkle dot */}
+                  <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-white shadow-[0_0_3px_rgba(99,102,241,0.5)]" />
+                </div>
+              )}
+              {project.stickerText && (
+                <div
+                  className={`
                                     pointer-events-none select-none
                                     absolute bottom-4 right-4
                                     w-8 h-8
@@ -110,66 +136,69 @@ const PortfolioCard: React.FC<PortfolioCardProps> = ({ project, className, onCli
                                     rounded-full shadow-lg
                                     bg-gradient-to-br from-amber-300 via-yellow-300 to-amber-500
                                     `}
-                                aria-hidden
-                                >
-                                {/* 하이라이트(광택) */}
-                                    <span
-                                        className="
+                  aria-hidden
+                >
+                  {/* 하이라이트(광택) */}
+                  <span
+                    className="
                                             absolute -top-1 -left-1 w-10 h-10 rounded-full
                                             bg-[radial-gradient(circle_at_30%_30%,rgba(255,255,255,0.7),rgba(255,255,255,0)_60%)]
                                         "
-                                    />
+                  />
 
-                                    <div className="flex flex-col items-center justify-center leading-none">
-                                        <span className="text-white font-extrabold [text-shadow:0_0_1px_#000,0.5px_0.5px_0.5px_#000]" >
-                                        {project.stickerText}
-                                        </span>
-                                    </div>
+                  <div className="flex flex-col items-center justify-center leading-none">
+                    <span className="text-white font-extrabold [text-shadow:0_0_1px_#000,0.5px_0.5px_0.5px_#000]">
+                      {project.stickerText}
+                    </span>
+                  </div>
 
-                                    {/* 리본 꼬리 (좌/우) */}
-                                    <span
-                                    className="
+                  {/* 리본 꼬리 (좌/우) */}
+                  <span
+                    className="
                                         absolute -bottom-1.5 left-1.5 w-2.5 h-3
                                         [clip-path:polygon(0%_0%,100%_0%,50%_100%)]
                                         rotate-[-90deg]
                                         bg-gradient-to-l from-red-400 via-red-500 to-red-700  
                                     "
-                                    />
-                                    <span
-                                    className="
+                  />
+                  <span
+                    className="
                                         absolute -bottom-1.5 right-1.5 w-2.5 h-3
                                         [clip-path:polygon(0%_0%,100%_0%,50%_100%)]
                                         rotate-[90deg]
                                         bg-gradient-to-r from-red-400 via-red-500 to-red-700
                                     "
-                                    />
-                                </div>
-                            )}
-                        </div>
-                    </div>
-
-                    <div
-                        className="absolute w-full h-full"
-                        style={{ backfaceVisibility: 'hidden', transform: 'rotateY(180deg)' }}
-                    >
-                        <div className="bg-slate-800 text-white rounded-card shadow-lg flex flex-col items-center justify-center p-6 w-full h-full">
-                            <h4 className="text-xl font-bold mb-4">Tech Stack</h4>
-                            <div className="flex flex-wrap justify-center gap-2">
-                                {project.techStack?.map((tech) => (
-                                    <span
-                                        key={tech}
-                                        className="bg-accent-500 text-white text-sm font-medium px-3 py-1 rounded-full"
-                                    >
-                                        {tech}
-                                    </span>
-                                ))}
-                            </div>
-                        </div>
-                    </div>
+                  />
                 </div>
+              )}
             </div>
+          </div>
+
+          <div
+            className="absolute w-full h-full"
+            style={{
+              backfaceVisibility: "hidden",
+              transform: "rotateY(180deg)",
+            }}
+          >
+            <div className="bg-slate-800 text-white rounded-card shadow-lg flex flex-col items-center justify-center p-5 w-full h-full sm:p-6">
+              <h4 className="text-lg font-bold mb-4 sm:text-xl">Tech Stack</h4>
+              <div className="flex flex-wrap justify-center gap-2">
+                {project.techStack?.map((tech) => (
+                  <span
+                    key={tech}
+                    className="bg-accent-500 text-white text-xs font-medium px-2.5 py-1 rounded-full sm:text-sm sm:px-3"
+                  >
+                    {tech}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
         </div>
-    );
+      </div>
+    </div>
+  );
 };
 
 export default PortfolioCard;

--- a/src/components/PreparingCard/index.tsx
+++ b/src/components/PreparingCard/index.tsx
@@ -23,8 +23,8 @@ const PreparingCard: React.FC<PreparingCardProps> = ({ project, className }) => 
 
     return (
         <div className={`block ${className || ''}`}>
-            <div className="bg-surface-subtle rounded-card shadow-sm overflow-hidden flex flex-col aspect-[9/16] border-2 border-dashed border-line-strong">
-                <div className="relative w-full aspect-square p-4">
+            <div className="bg-surface-subtle rounded-card shadow-sm overflow-hidden flex flex-col aspect-[24/41] border-2 border-dashed border-line-strong">
+                <div className="relative w-full aspect-square p-3 sm:p-4">
                     <img
                         src={`https://placehold.co/300x300/e2e8f0/9ca3af?text=Coming+Soon`}
                         // alt 속성도 번역 처리합니다.
@@ -33,16 +33,16 @@ const PreparingCard: React.FC<PreparingCardProps> = ({ project, className }) => 
                         onError={handleImageError}
                     />
                 </div>
-                <div className="px-6 pb-4 flex flex-col flex-grow overflow-y-auto">
-                    <h3 className="text-2xl font-bold mb-2 truncate">
+                <div className="px-5 pb-4 flex flex-col flex-grow overflow-y-auto sm:px-6">
+                    <h3 className="mb-2 line-clamp-2 min-h-[3.2rem] text-lg font-bold leading-tight sm:min-h-[3.6rem] sm:text-[1.35rem]">
                         {/* 준비중인 프로젝트의 제목도 t 함수로 감싸줍니다. */}
                         {t(project.title)}
                     </h3>
                     <p className="
-                        text-content-secondary mb-2 hidden sm:block
-                        text-sm h-10
-                        md:text-base md:h-20
+                        mb-2 hidden min-h-[3.8rem]
+                        text-sm leading-relaxed text-content-secondary
                         line-clamp-3
+                        sm:block sm:text-[0.95rem]
                     ">
                         {t(project.subtitle || '')}
                     </p>

--- a/src/components/ProjectFlipPreviewCard.tsx
+++ b/src/components/ProjectFlipPreviewCard.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useProjectFlipPreview } from '../hooks/useProjectFlipPreview';
+import type { ProjectSummary } from '../types';
+
+interface ProjectFlipPreviewCardProps {
+    projects: ProjectSummary[];
+}
+
+const ProjectFlipPreviewCard: React.FC<ProjectFlipPreviewCardProps> = ({ projects }) => {
+    const { t } = useTranslation('projects');
+    const previewProjects = projects.slice(0, 2);
+    const { activeProjectIndex, isFlipped } = useProjectFlipPreview(previewProjects.length);
+
+    const activeProject = previewProjects[activeProjectIndex] ?? previewProjects[0];
+    const previewTechStack = activeProject?.techStack?.slice(0, 4) ?? [];
+
+    const handleImageError = (event: React.SyntheticEvent<HTMLImageElement, Event>) => {
+        event.currentTarget.onerror = null;
+        event.currentTarget.src = "https://placehold.co/300x300/cccccc/333333?text=Project+Image";
+    };
+
+    if (!activeProject) return null;
+
+    return (
+        <div className="mx-auto flex w-full max-w-[220px] flex-col items-center gap-3">
+            <div className="text-center">
+            </div>
+
+            <div className="w-[150px] sm:w-[170px]" style={{ perspective: '1000px' }}>
+                <div
+                    className="relative aspect-[24/41] w-full transition-transform duration-700"
+                    style={{
+                        transformStyle: 'preserve-3d',
+                        transform: isFlipped ? 'rotateY(180deg)' : 'rotateY(0deg)',
+                    }}
+                >
+                    <div className="absolute inset-0" style={{ backfaceVisibility: 'hidden' }}>
+                        <div className="flex h-full flex-col overflow-hidden rounded-card bg-surface shadow-md">
+                            <div className="p-2.5">
+                                <img
+                                    src={activeProject.screenshots.length > 0 ? activeProject.screenshots[0].src : "https://placehold.co/300x300/cccccc/333333?text=Project+Image"}
+                                    alt={`${t(activeProject.title || '')} Thumbnail`}
+                                    className="aspect-square w-full rounded-[1.8rem] object-contain"
+                                    onError={handleImageError}
+                                />
+                            </div>
+                            <div className="flex flex-1 flex-col px-4 pb-3">
+                                <h4 className="line-clamp-2 text-sm font-bold leading-tight text-content">
+                                    {t(activeProject.title || '')}
+                                </h4>
+                                <p className="mt-2 line-clamp-2 text-[11px] leading-relaxed text-content-secondary">
+                                    {t(activeProject.subtitle || '')}
+                                </p>
+                                <span className="mt-auto inline-flex w-fit rounded-full bg-accent-100 px-2 py-0.5 text-[10px] font-semibold text-accent-700">
+                                    {t(activeProject.projectType || '')}
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div
+                        className="absolute inset-0"
+                        style={{ backfaceVisibility: 'hidden', transform: 'rotateY(180deg)' }}
+                    >
+                        <div className="flex h-full flex-col items-center justify-center rounded-card bg-slate-800 px-4 py-5 text-white shadow-md">
+                            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/60">
+                                Tech Stack
+                            </p>
+                            <div className="mt-4 flex flex-wrap justify-center gap-1.5">
+                                {previewTechStack.map((tech) => (
+                                    <span
+                                        key={tech}
+                                        className="rounded-full bg-accent-500 px-2 py-1 text-[10px] font-semibold text-white"
+                                    >
+                                        {tech}
+                                    </span>
+                                ))}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ProjectFlipPreviewCard;

--- a/src/components/ProjectsSidebar.tsx
+++ b/src/components/ProjectsSidebar.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+import { PROJECT_CARD_EASE } from '../hooks/useProjectGridEntrance';
+import type { ProjectDevKitCardData, ProjectDevKitId } from '../hooks/useProjectDevKitItems';
+import type { ProjectSummary } from '../types';
+import AiDevKitCard from './AiDevKitCard';
+import ProjectFlipPreviewCard from './ProjectFlipPreviewCard';
+import StickySectionSidebar from './StickySectionSidebar';
+
+interface ProjectsSidebarProps {
+    title: string;
+    subtitle: string;
+    projects: ProjectSummary[];
+    hasPlayedProjectEntrance: boolean;
+    showAiDevKit: boolean;
+    devKitTitle: string;
+    devKitItems: ProjectDevKitCardData[];
+    onSelectDevKit: (id: ProjectDevKitId) => void;
+}
+
+const ProjectsSidebar: React.FC<ProjectsSidebarProps> = ({
+    title,
+    subtitle,
+    projects,
+    hasPlayedProjectEntrance,
+    showAiDevKit,
+    devKitTitle,
+    devKitItems,
+    onSelectDevKit,
+}) => {
+    return (
+        <StickySectionSidebar title={title} subtitle={subtitle}>
+            {projects.length > 0 && (
+                <motion.div
+                    initial={{ opacity: 0, y: 18 }}
+                    animate={hasPlayedProjectEntrance ? { opacity: 1, y: 0 } : { opacity: 0, y: 18 }}
+                    transition={{ duration: 0.45, ease: PROJECT_CARD_EASE }}
+                >
+                    <ProjectFlipPreviewCard projects={projects} />
+                </motion.div>
+            )}
+
+            {showAiDevKit && (
+                <motion.div
+                    initial={{ opacity: 0, y: 36, scale: 0.98, filter: 'blur(10px)' }}
+                    animate={{ opacity: 1, y: 0, scale: 1, filter: 'blur(0px)' }}
+                    transition={{ duration: 0.55, ease: PROJECT_CARD_EASE }}
+                    className={projects.length > 0 ? "mt-8" : undefined}
+                >
+                    <div className="rounded-card bg-surface p-4 shadow-lg sm:p-5">
+                        <div className="mb-4">
+                            <span className="text-[11px] font-semibold uppercase tracking-[0.2em] text-content-muted">
+                                AI Layer
+                            </span>
+                            <div className="mt-1 flex flex-wrap items-center justify-center gap-2 lg:justify-start">
+                                <h3 className="text-lg font-bold text-title">
+                                    {devKitTitle}
+                                </h3>
+                            </div>
+                        </div>
+                        <div className="grid grid-cols-3 gap-3">
+                            {devKitItems.map((item) => (
+                                <AiDevKitCard
+                                    key={item.id}
+                                    icon={item.icon}
+                                    title={item.title}
+                                    description={item.description}
+                                    onClick={() => onSelectDevKit(item.id)}
+                                />
+                            ))}
+                        </div>
+                    </div>
+                </motion.div>
+            )}
+        </StickySectionSidebar>
+    );
+};
+
+export default ProjectsSidebar;

--- a/src/components/StickySectionSidebar.tsx
+++ b/src/components/StickySectionSidebar.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface StickySectionSidebarProps {
+    title: string;
+    subtitle?: string;
+    children?: React.ReactNode;
+}
+
+const StickySectionSidebar: React.FC<StickySectionSidebarProps> = ({
+    title,
+    subtitle,
+    children,
+}) => {
+    return (
+        <div className="lg:sticky lg:top-24">
+            <div className="flex flex-col items-center justify-center">
+                <h2 className="text-3xl font-bold text-content sm:text-4xl lg:text-5xl">
+                    {title}
+                </h2>
+                <div className="mt-3 mx-auto h-1 w-12 rounded-full bg-accent-600 lg:mx-0" />
+            </div>
+
+            {subtitle ? (
+                <p className="mt-4 text-center text-sm leading-relaxed text-content-muted">
+                    {subtitle}
+                </p>
+            ) : null}
+
+            {children ? <div className="mt-8">{children}</div> : null}
+        </div>
+    );
+};
+
+export default StickySectionSidebar;

--- a/src/hooks/useProjectDevKitItems.tsx
+++ b/src/hooks/useProjectDevKitItems.tsx
@@ -1,0 +1,107 @@
+import type { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type {
+    AiDevKitDetailItem,
+    AiDevKitModalData,
+    AiDevKitSkillItem,
+} from '../components/AiDevKitModal';
+
+export type ProjectDevKitId = 'skills' | 'mcp' | 'harness';
+
+export type ProjectDevKitCardData = AiDevKitModalData & {
+    id: ProjectDevKitId;
+    description: string;
+    icon: ReactNode;
+};
+
+export const useProjectDevKitItems = () => {
+    const { t } = useTranslation('projects');
+
+    const skillItems = t('aiDevKit.skills.detail.cardItems', {
+        returnObjects: true,
+    }) as AiDevKitSkillItem[];
+    const mcpServersItems = t('aiDevKit.mcp.detail.serversItems', {
+        returnObjects: true,
+    }) as AiDevKitDetailItem[];
+    const harnessPatternItems = t('aiDevKit.harness.detail.patternsItems', {
+        returnObjects: true,
+    }) as AiDevKitDetailItem[];
+    const harnessAbstractItems = t('aiDevKit.harness.detail.abstractItems', {
+        returnObjects: true,
+    }) as AiDevKitDetailItem[];
+
+    const closeLabel = t('aiDevKit.modal.close');
+
+    return [
+        {
+            id: 'skills',
+            icon: (
+                <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M12 2L15.09 8.26L22 9.27L17 14.14L18.18 21.02L12 17.77L5.82 21.02L7 14.14L2 9.27L8.91 8.26L12 2Z" />
+                </svg>
+            ),
+            title: t('aiDevKit.skills.title'),
+            description: t('aiDevKit.skills.description'),
+            eyebrow: t('aiDevKit.skills.detail.eyebrow'),
+            summary: t('aiDevKit.skills.detail.summary'),
+            closeLabel,
+            sections: [
+                {
+                    title: t('aiDevKit.skills.detail.skillsTitle'),
+                    description: t('aiDevKit.skills.detail.skillsDescription'),
+                    skillItems,
+                    layout: 'skill-groups',
+                },
+            ],
+        },
+        {
+            id: 'mcp',
+            icon: (
+                <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+                    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+                </svg>
+            ),
+            title: t('aiDevKit.mcp.title'),
+            description: t('aiDevKit.mcp.description'),
+            eyebrow: t('aiDevKit.mcp.detail.eyebrow'),
+            summary: t('aiDevKit.mcp.detail.summary'),
+            closeLabel,
+            sections: [
+                {
+                    title: t('aiDevKit.mcp.detail.serversTitle'),
+                    items: mcpServersItems,
+                },
+            ],
+        },
+        {
+            id: 'harness',
+            icon: (
+                <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <circle cx="12" cy="12" r="3" />
+                    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+                </svg>
+            ),
+            title: t('aiDevKit.harness.title'),
+            description: t('aiDevKit.harness.description'),
+            eyebrow: t('aiDevKit.harness.detail.eyebrow'),
+            summary: t('aiDevKit.harness.detail.summary'),
+            closeLabel,
+            sections: [
+                {
+                    title: t('aiDevKit.harness.detail.abstractTitle'),
+                    description: t('aiDevKit.harness.detail.abstractDescription'),
+                    items: harnessAbstractItems,
+                    layout: 'diagram',
+                },
+                {
+                    title: t('aiDevKit.harness.detail.patternsTitle'),
+                    description: t('aiDevKit.harness.detail.patternsDescription'),
+                    items: harnessPatternItems,
+                    layout: 'flow',
+                },
+            ],
+        },
+    ] as ProjectDevKitCardData[];
+};

--- a/src/hooks/useProjectFlipPreview.ts
+++ b/src/hooks/useProjectFlipPreview.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+export const useProjectFlipPreview = (projectCount: number, intervalMs = 2000) => {
+    const [stepIndex, setStepIndex] = useState(0);
+
+    useEffect(() => {
+        setStepIndex(0);
+    }, [projectCount]);
+
+    useEffect(() => {
+        if (projectCount === 0) return;
+
+        const intervalId = window.setInterval(() => {
+            setStepIndex((previous) => {
+                const totalSteps = projectCount * 2;
+                return (previous + 1) % totalSteps;
+            });
+        }, intervalMs);
+
+        return () => {
+            window.clearInterval(intervalId);
+        };
+    }, [intervalMs, projectCount]);
+
+    return {
+        activeProjectIndex: Math.floor(stepIndex / 2),
+        isFlipped: stepIndex % 2 === 1,
+    };
+};

--- a/src/hooks/useProjectGridEntrance.ts
+++ b/src/hooks/useProjectGridEntrance.ts
@@ -1,0 +1,170 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useInView } from 'framer-motion';
+
+import type { ProjectSummary } from '../types';
+
+export const PROJECT_CARD_EASE: [number, number, number, number] = [0.22, 1, 0.36, 1];
+
+export type ProjectCardCustom = {
+    id: string;
+    index: number;
+};
+
+type ProjectCardOffset = {
+    x: number;
+    y: number;
+    zIndex: number;
+};
+
+type UseProjectGridEntranceArgs = {
+    projects: ProjectSummary[];
+    selectedId: string | null;
+};
+
+export const useProjectGridEntrance = ({
+    projects,
+    selectedId,
+}: UseProjectGridEntranceArgs) => {
+    const projectsGridRef = useRef<HTMLDivElement | null>(null);
+    const projectCardRefs = useRef<Record<string, HTMLDivElement | null>>({});
+    const isProjectsGridInView = useInView(projectsGridRef, {
+        once: true,
+        amount: 0.18,
+    });
+
+    const [projectCardOffsets, setProjectCardOffsets] = useState<Record<string, ProjectCardOffset>>({});
+    const [hasPlayedProjectEntrance, setHasPlayedProjectEntrance] = useState(false);
+    const [showAiDevKit, setShowAiDevKit] = useState(false);
+
+    useLayoutEffect(() => {
+        if (projects.length === 0) return;
+
+        const updateProjectCardOffsets = () => {
+            const gridElement = projectsGridRef.current;
+            if (!gridElement) return;
+
+            const gridRect = gridElement.getBoundingClientRect();
+            const gridCenterX = gridRect.left + gridRect.width / 2;
+            const gridCenterY = gridRect.top + gridRect.height / 2;
+            const nextOffsets: Record<string, ProjectCardOffset> = {};
+
+            for (const project of projects) {
+                const cardElement = projectCardRefs.current[project.id];
+                if (!cardElement) return;
+
+                const cardRect = cardElement.getBoundingClientRect();
+                const cardCenterX = cardRect.left + cardRect.width / 2;
+                const cardCenterY = cardRect.top + cardRect.height / 2;
+                const deltaX = gridCenterX - cardCenterX;
+                const deltaY = gridCenterY - cardCenterY;
+                const centerDistance = Math.abs(deltaX) + Math.abs(deltaY);
+
+                nextOffsets[project.id] = {
+                    x: deltaX,
+                    y: deltaY,
+                    zIndex: Math.max(1, Math.round(1000 - centerDistance)),
+                };
+            }
+
+            setProjectCardOffsets(nextOffsets);
+        };
+
+        updateProjectCardOffsets();
+        window.addEventListener('resize', updateProjectCardOffsets);
+
+        return () => {
+            window.removeEventListener('resize', updateProjectCardOffsets);
+        };
+    }, [projects]);
+
+    const projectCardOffsetsReady =
+        projects.length > 0 && projects.every((project) => Boolean(projectCardOffsets[project.id]));
+
+    useEffect(() => {
+        if (!projectCardOffsetsReady || hasPlayedProjectEntrance || !isProjectsGridInView) return;
+
+        const animationFrame = window.requestAnimationFrame(() => {
+            setHasPlayedProjectEntrance(true);
+        });
+
+        return () => {
+            window.cancelAnimationFrame(animationFrame);
+        };
+    }, [projectCardOffsetsReady, hasPlayedProjectEntrance, isProjectsGridInView]);
+
+    useEffect(() => {
+        if (!hasPlayedProjectEntrance || showAiDevKit) return;
+
+        const lastCardDelay = 0.08 + Math.max(projects.length - 1, 0) * 0.05;
+        const revealDelayMs = (lastCardDelay + 1.05) * 1000;
+        const timeoutId = window.setTimeout(() => {
+            setShowAiDevKit(true);
+        }, revealDelayMs);
+
+        return () => {
+            window.clearTimeout(timeoutId);
+        };
+    }, [hasPlayedProjectEntrance, projects.length, showAiDevKit]);
+
+    const getProjectCardClusterState = ({ id, index }: ProjectCardCustom) => {
+        const offset = projectCardOffsets[id];
+
+        if (!offset) {
+            return {
+                opacity: 0,
+                scale: 0.8,
+                x: 0,
+                y: 0,
+                rotate: 0,
+                filter: 'blur(12px)',
+                zIndex: projects.length - index,
+            };
+        }
+
+        return {
+            opacity: 0,
+            scale: 0.68,
+            x: offset.x,
+            y: offset.y,
+            rotate: 0,
+            filter: 'blur(12px)',
+            zIndex: offset.zIndex,
+        };
+    };
+
+    const cardVariants = {
+        cluster: (custom: ProjectCardCustom) => ({
+            ...getProjectCardClusterState(custom),
+            transition: { duration: 0 },
+        }),
+        animate: ({ index }: ProjectCardCustom) => ({
+            opacity: 1,
+            scale: 1,
+            x: 0,
+            y: 0,
+            rotate: 0,
+            filter: 'blur(0px)',
+            zIndex: 1,
+            transition: {
+                delay: 0.08 + index * 0.05,
+                duration: 0.9,
+                ease: PROJECT_CARD_EASE,
+            },
+        }),
+        exit: ({ id }: ProjectCardCustom) => {
+            if (id === selectedId) {
+                return { scale: 1.5, opacity: 0, transition: { duration: 0.3 } };
+            }
+            return { opacity: 0, transition: { duration: 0.2 } };
+        },
+    };
+
+    return {
+        projectsGridRef,
+        projectCardRefs,
+        projectCardOffsetsReady,
+        hasPlayedProjectEntrance,
+        showAiDevKit,
+        cardVariants,
+    };
+};

--- a/src/hooks/useProjectLists.ts
+++ b/src/hooks/useProjectLists.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+
+import type { PreparingProjectData } from '../components/PreparingCard';
+import type { ProjectSummary } from '../types';
+
+type PrefetchedLists = {
+    projects: ProjectSummary[];
+    preparing: PreparingProjectData[];
+};
+
+let cachedLists: PrefetchedLists | null = null;
+
+const listsPromise = Promise.all([
+    fetch('/data/projects-list.json').then((response) => response.json()),
+    fetch('/data/preparing-projects-list.json').then((response) => response.json()),
+]).then(([projects, preparing]) => {
+    cachedLists = { projects, preparing };
+    return cachedLists;
+}).catch(console.error);
+
+export const useProjectLists = () => {
+    const [projects, setProjects] = useState<ProjectSummary[]>(cachedLists?.projects ?? []);
+    const [preparingProjects, setPreparingProjects] = useState<PreparingProjectData[]>(cachedLists?.preparing ?? []);
+    const [isLoading, setIsLoading] = useState(!cachedLists);
+
+    useEffect(() => {
+        if (cachedLists) return;
+
+        listsPromise.then((data) => {
+            if (data) {
+                setProjects(data.projects);
+                setPreparingProjects(data.preparing);
+            }
+            setIsLoading(false);
+        });
+    }, []);
+
+    return {
+        projects,
+        preparingProjects,
+        isLoading,
+    };
+};

--- a/src/sections/home/ProjectsSection.tsx
+++ b/src/sections/home/ProjectsSection.tsx
@@ -1,16 +1,16 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
 
 import PortfolioCard from "../../components/PortfolioCard";
-import PreparingCard, { type PreparingProjectData } from "../../components/PreparingCard";
-import AiDevKitCard from "../../components/AiDevKitCard";
-import AiDevKitModal, {
-    type AiDevKitDetailItem,
-    type AiDevKitModalData,
-    type AiDevKitSkillItem,
-} from "../../components/AiDevKitModal";
+import PreparingCard from "../../components/PreparingCard";
+import AiDevKitModal from "../../components/AiDevKitModal";
+import ProjectsSidebar from "../../components/ProjectsSidebar";
+import StickySectionSidebar from "../../components/StickySectionSidebar";
+import { useProjectDevKitItems, type ProjectDevKitId } from '../../hooks/useProjectDevKitItems';
+import { useProjectGridEntrance } from '../../hooks/useProjectGridEntrance';
+import { useProjectLists } from '../../hooks/useProjectLists';
 import type { ProjectSummary } from '../../types';
 import { durations } from '../../design-tokens';
 
@@ -19,43 +19,24 @@ const sectionExitAnimation = {
     transition: { duration: durations.fast }
 };
 
-// ── Prefetch: 모듈 로드 시 즉시 fetch 시작 ──────────────────────
-type PrefetchedLists = { projects: ProjectSummary[]; preparing: PreparingProjectData[] };
-let cachedLists: PrefetchedLists | null = null;
-const listsPromise = Promise.all([
-    fetch('/data/projects-list.json').then(r => r.json()),
-    fetch('/data/preparing-projects-list.json').then(r => r.json()),
-]).then(([projects, preparing]) => {
-    cachedLists = { projects, preparing };
-    return cachedLists;
-}).catch(console.error);
-
-type DevKitId = 'skills' | 'mcp' | 'harness';
-type DevKitCardData = AiDevKitModalData & {
-    id: DevKitId;
-    description: string;
-};
-
 const ProjectsSection: React.FC = () => {
     const { t } = useTranslation(['projects', 'prepareProjects']);
     const navigate = useNavigate();
-
     const [selectedId, setSelectedId] = useState<string | null>(null);
-    const [selectedDevKitId, setSelectedDevKitId] = useState<DevKitId | null>(null);
-    const [projects, setProjects] = useState<ProjectSummary[]>(cachedLists?.projects ?? []);
-    const [preparingProjects, setPreparingProjects] = useState<PreparingProjectData[]>(cachedLists?.preparing ?? []);
-    const [isLoading, setIsLoading] = useState(!cachedLists);
-
-    useEffect(() => {
-        if (cachedLists) return;
-        listsPromise.then((data) => {
-            if (data) {
-                setProjects(data.projects);
-                setPreparingProjects(data.preparing);
-            }
-            setIsLoading(false);
-        });
-    }, []);
+    const [selectedDevKitId, setSelectedDevKitId] = useState<ProjectDevKitId | null>(null);
+    const { projects, preparingProjects, isLoading } = useProjectLists();
+    const {
+        projectsGridRef,
+        projectCardRefs,
+        projectCardOffsetsReady,
+        hasPlayedProjectEntrance,
+        showAiDevKit,
+        cardVariants,
+    } = useProjectGridEntrance({
+        projects,
+        selectedId,
+    });
+    const devKitItems = useProjectDevKitItems();
 
     const handleCardClick = (projectId: string) => {
         setSelectedId(projectId);
@@ -63,106 +44,6 @@ const ProjectsSection: React.FC = () => {
             navigate(`/project/${projectId}`);
         }, 300);
     };
-
-    const cardVariants = {
-        exit: (custom: string) => {
-            if (custom === selectedId) {
-                return { scale: 1.5, opacity: 0, transition: { duration: 0.3 } };
-            }
-            return { opacity: 0, transition: { duration: 0.2 } };
-        }
-    };
-
-    const skillItems = t('aiDevKit.skills.detail.cardItems', {
-        ns: 'projects',
-        returnObjects: true,
-    }) as AiDevKitSkillItem[];
-    const mcpServersItems = t('aiDevKit.mcp.detail.serversItems', {
-        ns: 'projects',
-        returnObjects: true,
-    }) as AiDevKitDetailItem[];
-    const harnessPatternItems = t('aiDevKit.harness.detail.patternsItems', {
-        ns: 'projects',
-        returnObjects: true,
-    }) as AiDevKitDetailItem[];
-    const harnessAbstractItems = t('aiDevKit.harness.detail.abstractItems', {
-        ns: 'projects',
-        returnObjects: true,
-    }) as AiDevKitDetailItem[];
-
-    const closeLabel = t('aiDevKit.modal.close', { ns: 'projects' });
-
-    const devKitItems: DevKitCardData[] = [
-        {
-            id: 'skills',
-            icon: (
-                <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M12 2L15.09 8.26L22 9.27L17 14.14L18.18 21.02L12 17.77L5.82 21.02L7 14.14L2 9.27L8.91 8.26L12 2Z" />
-                </svg>
-            ),
-            title: t('aiDevKit.skills.title', { ns: 'projects' }),
-            description: t('aiDevKit.skills.description', { ns: 'projects' }),
-            eyebrow: t('aiDevKit.skills.detail.eyebrow', { ns: 'projects' }),
-            summary: t('aiDevKit.skills.detail.summary', { ns: 'projects' }),
-            closeLabel,
-            sections: [
-                {
-                    title: t('aiDevKit.skills.detail.skillsTitle', { ns: 'projects' }),
-                    description: t('aiDevKit.skills.detail.skillsDescription', { ns: 'projects' }),
-                    skillItems,
-                    layout: 'skill-groups',
-                },
-            ],
-        },
-        {
-            id: 'mcp',
-            icon: (
-                <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-                    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-                </svg>
-            ),
-            title: t('aiDevKit.mcp.title', { ns: 'projects' }),
-            description: t('aiDevKit.mcp.description', { ns: 'projects' }),
-            eyebrow: t('aiDevKit.mcp.detail.eyebrow', { ns: 'projects' }),
-            summary: t('aiDevKit.mcp.detail.summary', { ns: 'projects' }),
-            closeLabel,
-            sections: [
-                {
-                    title: t('aiDevKit.mcp.detail.serversTitle', { ns: 'projects' }),
-                    items: mcpServersItems,
-                },
-            ],
-        },
-        {
-            id: 'harness',
-            icon: (
-                <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <circle cx="12" cy="12" r="3" />
-                    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-                </svg>
-            ),
-            title: t('aiDevKit.harness.title', { ns: 'projects' }),
-            description: t('aiDevKit.harness.description', { ns: 'projects' }),
-            eyebrow: t('aiDevKit.harness.detail.eyebrow', { ns: 'projects' }),
-            summary: t('aiDevKit.harness.detail.summary', { ns: 'projects' }),
-            closeLabel,
-            sections: [
-                {
-                    title: t('aiDevKit.harness.detail.abstractTitle', { ns: 'projects' }),
-                    description: t('aiDevKit.harness.detail.abstractDescription', { ns: 'projects' }),
-                    items: harnessAbstractItems,
-                    layout: 'diagram',
-                },
-                {
-                    title: t('aiDevKit.harness.detail.patternsTitle', { ns: 'projects' }),
-                    description: t('aiDevKit.harness.detail.patternsDescription', { ns: 'projects' }),
-                    items: harnessPatternItems,
-                    layout: 'flow',
-                },
-            ],
-        },
-    ];
 
     const activeDevKitItem = devKitItems.find((item) => item.id === selectedDevKitId) ?? null;
 
@@ -183,81 +64,73 @@ const ProjectsSection: React.FC = () => {
 
     return (
         <>
-            <section id="projects" className="min-h-screen flex flex-col items-center justify-center pt-20">
-                <div className="w-full max-w-6xl p-2 md:p-4 animate-fade-in">
-                    <motion.div
-                        exit={sectionExitAnimation}
-                        className="mb-10 text-center"
-                    >
-                        <h2 className="text-4xl sm:text-5xl font-bold text-content">
-                            {t('projectTitle', { ns: 'projects' })}
-                        </h2>
-                        <div className="mt-3 mx-auto w-12 h-1 rounded-full bg-accent-600" />
-                        <p className="mt-2 text-sm text-content-muted">
-                            {t('projectSubtitle', { ns: 'projects' })}
-                        </p>
-                    </motion.div>
+            <section id="projects" className="min-h-screen pt-20">
+                <div className="mx-auto w-full max-w-7xl px-3 py-6 md:px-5 lg:px-8 animate-fade-in">
+                    <div className="lg:grid lg:grid-cols-[minmax(220px,280px)_minmax(0,1fr)] lg:gap-10 xl:grid-cols-[minmax(240px,320px)_minmax(0,1fr)] xl:gap-14">
+                        <motion.div
+                            exit={sectionExitAnimation}
+                            className="mb-10 text-center lg:mb-0 lg:text-left"
+                        >
+                            <ProjectsSidebar
+                                title={t('projectTitle', { ns: 'projects' })}
+                                subtitle={t('projectSubtitle', { ns: 'projects' })}
+                                projects={projects}
+                                hasPlayedProjectEntrance={hasPlayedProjectEntrance}
+                                showAiDevKit={showAiDevKit}
+                                devKitTitle={t('aiDevKit.title', { ns: 'projects' })}
+                                devKitItems={devKitItems}
+                                onSelectDevKit={setSelectedDevKitId}
+                            />
+                        </motion.div>
 
-                    {/* AI DevKit */}
-                    <div className="px-4 mb-10">
-                        <div className="rounded-card bg-surface p-5 shadow-lg">
-                            <div className="flex items-center gap-2 mb-3">
-                                <h3 className="text-lg font-bold text-title">
-                                    {t('aiDevKit.title', { ns: 'projects' })}
-                                </h3>
-                                <span className="text-xs text-content-muted font-medium">
-                                    {t('aiDevKit.subtitle', { ns: 'projects' })}
-                                </span>
-                            </div>
-                            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-                                {devKitItems.map((item) => (
-                                    <AiDevKitCard
-                                        key={item.id}
-                                        icon={item.icon}
-                                        title={item.title}
-                                        description={item.description}
-                                        onClick={() => setSelectedDevKitId(item.id)}
-                                    />
+                        <div className="min-w-0">
+                            <div
+                                ref={projectsGridRef}
+                                className="grid grid-cols-2 gap-5 md:grid-cols-3 lg:px-0 xl:grid-cols-3"
+                                style={{ opacity: projectCardOffsetsReady ? 1 : 0 }}
+                            >
+                                {projects.map((project, index) => (
+                                    <motion.div
+                                        key={project.id}
+                                        ref={(element) => {
+                                            projectCardRefs.current[project.id] = element;
+                                        }}
+                                        variants={cardVariants}
+                                        initial={false}
+                                        animate={hasPlayedProjectEntrance ? "animate" : "cluster"}
+                                        exit="exit"
+                                        custom={{ id: project.id, index }}
+                                        className="flex"
+                                    >
+                                        <PortfolioCard project={project as ProjectSummary} className="w-full" onClick={() => handleCardClick(project.id)}/>
+                                    </motion.div>
                                 ))}
                             </div>
                         </div>
                     </div>
-
-                    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 p-4">
-                        {projects.map((project) => (
-                            <motion.div
-                                key={project.id}
-                                variants={cardVariants}
-                                exit="exit"
-                                custom={project.id}
-                                className="flex"
-                            >
-                                <PortfolioCard project={project as ProjectSummary} className="w-full" onClick={() => handleCardClick(project.id)}/>
-                            </motion.div>
-                        ))}
-                    </div>
                 </div>
             </section>
 
-            <section id="preparing-projects" className="min-h-screen flex flex-col items-center justify-center pt-16">
+            <section id="preparing-projects" className="min-h-screen pt-16">
                 <motion.div
                     exit={sectionExitAnimation}
-                    className="w-full max-w-6xl p-2 md:p-4 animate-fade-in">
-                    <div className="mb-10 text-center">
-                        <h2 className="text-4xl sm:text-5xl font-bold text-content">
-                            {t('preparingProjectTitle', { ns: 'prepareProjects' })}
-                        </h2>
-                        <div className="mt-3 mx-auto w-12 h-1 rounded-full bg-accent-600" />
-                        <p className="mt-2 text-sm text-content-muted">
-                            {t('preparingProjectSubtitle', { ns: 'projects' })}
-                        </p>
-                    </div>
-                    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 p-4">
-                        {preparingProjects.map((project) => (
-                            <div key={project.id} className="flex">
-                                <PreparingCard project={project} className="w-full" />
-                            </div>
-                        ))}
+                    className="mx-auto w-full max-w-7xl px-3 py-6 md:px-5 lg:px-8 animate-fade-in"
+                >
+                    <div className="lg:grid lg:grid-cols-[minmax(220px,280px)_minmax(0,1fr)] lg:gap-10 xl:grid-cols-[minmax(240px,320px)_minmax(0,1fr)] xl:gap-14">
+                        <div className="mb-10 text-center lg:mb-0 lg:text-left">
+                            <StickySectionSidebar
+                                title={t('preparingProjectTitle', { ns: 'prepareProjects' })}
+                                subtitle={t('preparingProjectSubtitle', { ns: 'projects' })}
+                            />
+                        </div>
+
+                        <div className="grid grid-cols-2 gap-6 p-4 md:grid-cols-3 lg:px-0 xl:grid-cols-3">
+                            {preparingProjects.map((project) => (
+                                <div key={project.id} className="flex">
+                                    <PreparingCard project={project} className="w-full" />
+                                </div>
+                            ))}
+                        </div>
                     </div>
                 </motion.div>
             </section>


### PR DESCRIPTION
## Summary
- Split `ProjectsSection` into `ProjectsSidebar` / `StickySectionSidebar` wrappers and `ProjectFlipPreviewCard`
- Extract `useProjectLists`, `useProjectFlipPreview`, `useProjectGridEntrance`, `useProjectDevKitItems` hooks
- Refresh `Portfolio` / `Preparing` / `AiDevKit` card visuals with matching i18n strings (ko/en)

## Test plan
- [ ] `bun run build` passes (verified locally via pre-push hook)
- [ ] Visual check: projects section sticky sidebar behavior on desktop
- [ ] Visual check: flip preview card hover/touch interaction
- [ ] Locale check: ko/en project section copy renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)