### PR TITLE
Expand design tokens (shadows/radii/spacing) and sync the three sources

### DIFF
--- a/design-preview.html
+++ b/design-preview.html
@@ -36,20 +36,69 @@
     --border-default: #e2e8f0;  /* slate-200 */
     --border-strong: #cbd5e1;   /* slate-300 */
 
-    /* Shadows */
+    /* Shadows — generic */
     --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
     --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
     --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
     --shadow-2xl: 0 25px 50px -12px rgb(0 0 0 / 0.25);
     --shadow-glow: 0 0 12px rgba(99,102,241,0.3), inset 0 1px 0 rgba(255,255,255,0.4);
 
-    /* Radius */
+    /* Shadows — brand glow */
+    --shadow-glow-accent: 0 0 12px rgba(99,102,241,0.3), inset 0 1px 0 rgba(255,255,255,0.4);
+    --shadow-glow-accent-sm: 0 0 2px rgba(99,102,241,0.6);
+    --shadow-glow-accent-xs: 0 0 3px rgba(99,102,241,0.5);
+
+    /* Shadows — decorative */
+    --shadow-polaroid-sm: 2px 2px 7px 1px rgba(0,0,0,0.5);
+    --shadow-polaroid-md: 5px 5px 5px 1px rgba(0,0,0,0.5);
+    --shadow-polaroid-lg: 7px 7px 7px 1px rgba(0,0,0,0.5);
+    --shadow-star-glow: 0 0 10px #fff, 0 0 20px #fff;
+
+    /* Shadows — page-specific */
+    --shadow-post-card: 0 8px 24px rgba(0,0,0,0.28);
+    --shadow-post-card-lg: 0 10px 30px rgba(0,0,0,0.35);
+    --shadow-post-white-glow: 0 0 15px rgba(255,255,255,0.2);
+    --shadow-resume-paper: 0 24px 80px rgba(15,23,42,0.18);
+
+    /* Radius — generic */
     --radius-full: 9999px;
     --radius-3xl: 24px;
     --radius-2xl: 16px;
     --radius-xl: 12px;
     --radius-lg: 8px;
     --radius-md: 6px;
+
+    /* Radius — semantic */
+    --radius-card: 0.75rem;          /* 12px */
+    --radius-modal: 1rem;            /* 16px */
+    --radius-pill: 9999px;
+
+    /* Radius — app-specific */
+    --radius-card-soft-28: 1.75rem;  /* 28px */
+    --radius-card-chunky: 3rem;      /* 48px */
+    --radius-paper-edge: 1.4rem;     /* 22.4px */
+    --radius-paper-edge-lg: 2rem;    /* 32px */
+
+    /* Spacing — section + scroll viewport */
+    --spacing-section: 5rem;             /* 80px */
+    --spacing-hairline: 4px;
+    --spacing-scroll-viewport-half: 52vh;
+    --spacing-scroll-viewport-three-fifths: 55vh;
+    --spacing-scroll-viewport-full: 65vh;
+
+    /* Easings (functional, mirrored as code) */
+    --easing-toast: cubic-bezier(0.68, -0.55, 0.27, 1.55);
+    --easing-standard: ease-out;
+
+    /* Durations */
+    --duration-instant: 100ms;
+    --duration-micro: 150ms;
+    --duration-fast: 200ms;
+    --duration-page: 250ms;
+    --duration-item: 280ms;
+    --duration-standard: 300ms;
+    --duration-flip: 700ms;
+    --duration-toast-visible: 3000ms;
 
     /* Fonts */
     --font-body: 'Noto Sans KR', sans-serif;
@@ -187,6 +236,33 @@
   .spacing-row { display: flex; align-items: center; gap: 12px; margin-bottom: 8px; }
   .spacing-bar { height: 24px; background: var(--accent-100); border-radius: 4px; border: 1px solid var(--accent-500); }
   .spacing-label { font-size: 0.625rem; font-family: var(--font-mono); color: var(--text-muted); min-width: 48px; }
+
+  /* Code block (for easings & duration tokens) */
+  .code-block {
+    background: var(--bg-white);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-lg);
+    padding: 12px 16px;
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    margin-bottom: 8px;
+    line-height: 1.6;
+  }
+  .code-block .code-key { color: var(--accent-700); font-weight: 600; }
+  .code-block .code-comment { color: var(--text-muted); }
+
+  /* Token card grouping */
+  .token-group { margin-bottom: 28px; }
+  .token-group-title {
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: var(--text-meta);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: 12px;
+  }
+  .shadow-box-lg { width: 140px; height: 90px; background: var(--bg-white); border-radius: var(--radius-xl); display: flex; align-items: center; justify-content: center; font-size: 0.625rem; font-weight: 600; color: var(--text-muted); text-align: center; padding: 4px; }
 
   /* Glass Card */
   .glass-card {
@@ -345,40 +421,135 @@
   <!-- BORDER RADIUS -->
   <div class="section">
     <div class="section-title">Border Radius Scale</div>
-    <div class="radius-grid">
-      <div><div class="radius-box" style="border-radius:var(--radius-full);width:48px;height:48px">full</div></div>
-      <div><div class="radius-box" style="border-radius:var(--radius-3xl)">3xl</div></div>
-      <div><div class="radius-box" style="border-radius:var(--radius-2xl)">2xl</div></div>
-      <div><div class="radius-box" style="border-radius:var(--radius-xl)">xl</div></div>
-      <div><div class="radius-box" style="border-radius:var(--radius-lg)">lg</div></div>
-      <div><div class="radius-box" style="border-radius:var(--radius-md)">md</div></div>
+
+    <div class="token-group">
+      <div class="token-group-title">Generic</div>
+      <div class="radius-grid">
+        <div><div class="radius-box" style="border-radius:var(--radius-full);width:48px;height:48px">full</div></div>
+        <div><div class="radius-box" style="border-radius:var(--radius-3xl)">3xl</div></div>
+        <div><div class="radius-box" style="border-radius:var(--radius-2xl)">2xl</div></div>
+        <div><div class="radius-box" style="border-radius:var(--radius-xl)">xl</div></div>
+        <div><div class="radius-box" style="border-radius:var(--radius-lg)">lg</div></div>
+        <div><div class="radius-box" style="border-radius:var(--radius-md)">md</div></div>
+      </div>
+    </div>
+
+    <div class="token-group">
+      <div class="token-group-title">Semantic</div>
+      <div class="radius-grid">
+        <div><div class="radius-box" style="border-radius:var(--radius-card)">card<br>12px</div></div>
+        <div><div class="radius-box" style="border-radius:var(--radius-modal)">modal<br>16px</div></div>
+        <div><div class="radius-box" style="border-radius:var(--radius-pill);width:96px">pill</div></div>
+      </div>
+    </div>
+
+    <div class="token-group">
+      <div class="token-group-title">App-Specific</div>
+      <div class="radius-grid">
+        <div><div class="radius-box" style="border-radius:var(--radius-card-soft-28);width:80px;height:80px">card-soft-28<br>28px</div></div>
+        <div><div class="radius-box" style="border-radius:var(--radius-card-chunky);width:96px;height:96px">card-chunky<br>48px</div></div>
+        <div><div class="radius-box" style="border-radius:var(--radius-paper-edge);width:80px;height:80px">paper-edge<br>22.4px</div></div>
+        <div><div class="radius-box" style="border-radius:var(--radius-paper-edge-lg);width:88px;height:88px">paper-edge-lg<br>32px</div></div>
+      </div>
     </div>
   </div>
 
   <!-- SHADOWS -->
   <div class="section">
     <div class="section-title">Elevation & Shadows</div>
-    <div class="shadow-grid">
-      <div class="shadow-box" style="box-shadow:none;border:1px solid var(--border-default)">Flat</div>
-      <div class="shadow-box" style="box-shadow:var(--shadow-sm)">sm</div>
-      <div class="shadow-box" style="box-shadow:0 4px 6px -1px rgb(0 0 0 / 0.1)">md</div>
-      <div class="shadow-box" style="box-shadow:var(--shadow-lg)">lg</div>
-      <div class="shadow-box" style="box-shadow:var(--shadow-xl)">xl</div>
-      <div class="shadow-box" style="box-shadow:var(--shadow-2xl)">2xl</div>
-      <div class="shadow-box" style="box-shadow:var(--shadow-glow);background:linear-gradient(135deg,rgba(99,102,241,0.08),rgba(139,92,246,0.06))">glow</div>
+
+    <div class="token-group">
+      <div class="token-group-title">Generic</div>
+      <div class="shadow-grid">
+        <div class="shadow-box" style="box-shadow:none;border:1px solid var(--border-default)">Flat</div>
+        <div class="shadow-box" style="box-shadow:var(--shadow-sm)">sm</div>
+        <div class="shadow-box" style="box-shadow:0 4px 6px -1px rgb(0 0 0 / 0.1)">md</div>
+        <div class="shadow-box" style="box-shadow:var(--shadow-lg)">lg</div>
+        <div class="shadow-box" style="box-shadow:var(--shadow-xl)">xl</div>
+        <div class="shadow-box" style="box-shadow:var(--shadow-2xl)">2xl</div>
+      </div>
+    </div>
+
+    <div class="token-group">
+      <div class="token-group-title">Brand Glow</div>
+      <div class="shadow-grid">
+        <div class="shadow-box-lg" style="box-shadow:var(--shadow-glow-accent);background:linear-gradient(135deg,rgba(99,102,241,0.08),rgba(139,92,246,0.06))">glow-accent</div>
+        <div class="shadow-box-lg" style="box-shadow:var(--shadow-glow-accent-sm)">glow-accent-sm</div>
+        <div class="shadow-box-lg" style="box-shadow:var(--shadow-glow-accent-xs)">glow-accent-xs</div>
+      </div>
+    </div>
+
+    <div class="token-group">
+      <div class="token-group-title">Polaroid (Decorative Drop)</div>
+      <div class="shadow-grid">
+        <div class="shadow-box-lg" style="box-shadow:var(--shadow-polaroid-sm)">polaroid-sm</div>
+        <div class="shadow-box-lg" style="box-shadow:var(--shadow-polaroid-md)">polaroid-md</div>
+        <div class="shadow-box-lg" style="box-shadow:var(--shadow-polaroid-lg)">polaroid-lg</div>
+      </div>
+    </div>
+
+    <div class="token-group">
+      <div class="token-group-title">Star (Celestial)</div>
+      <div class="shadow-grid">
+        <div class="shadow-box-lg" style="box-shadow:var(--shadow-star-glow);background:#0f172a;color:#fff">star-glow</div>
+      </div>
+    </div>
+
+    <div class="token-group">
+      <div class="token-group-title">Page-Specific</div>
+      <div class="shadow-grid">
+        <div class="shadow-box-lg" style="box-shadow:var(--shadow-post-card)">post-card</div>
+        <div class="shadow-box-lg" style="box-shadow:var(--shadow-post-card-lg)">post-card-lg</div>
+        <div class="shadow-box-lg" style="box-shadow:var(--shadow-post-white-glow);background:#0f172a;color:#fff">post-white-glow</div>
+        <div class="shadow-box-lg" style="box-shadow:var(--shadow-resume-paper)">resume-paper</div>
+      </div>
     </div>
   </div>
 
   <!-- SPACING -->
   <div class="section">
     <div class="section-title">Spacing Scale</div>
-    <div class="spacing-row"><div class="spacing-label">4px</div><div class="spacing-bar" style="width:16px"></div></div>
-    <div class="spacing-row"><div class="spacing-label">8px</div><div class="spacing-bar" style="width:32px"></div></div>
-    <div class="spacing-row"><div class="spacing-label">16px (p-4)</div><div class="spacing-bar" style="width:64px"></div></div>
-    <div class="spacing-row"><div class="spacing-label">24px (p-6)</div><div class="spacing-bar" style="width:96px"></div></div>
-    <div class="spacing-row"><div class="spacing-label">32px (p-8)</div><div class="spacing-bar" style="width:128px"></div></div>
-    <div class="spacing-row"><div class="spacing-label">48px</div><div class="spacing-bar" style="width:192px"></div></div>
-    <div class="spacing-row"><div class="spacing-label">80px (pt-20)</div><div class="spacing-bar" style="width:320px"></div></div>
+
+    <div class="token-group">
+      <div class="token-group-title">General</div>
+      <div class="spacing-row"><div class="spacing-label">4px (hairline)</div><div class="spacing-bar" style="width:16px"></div></div>
+      <div class="spacing-row"><div class="spacing-label">8px</div><div class="spacing-bar" style="width:32px"></div></div>
+      <div class="spacing-row"><div class="spacing-label">16px (p-4)</div><div class="spacing-bar" style="width:64px"></div></div>
+      <div class="spacing-row"><div class="spacing-label">24px (p-6)</div><div class="spacing-bar" style="width:96px"></div></div>
+      <div class="spacing-row"><div class="spacing-label">32px (p-8)</div><div class="spacing-bar" style="width:128px"></div></div>
+      <div class="spacing-row"><div class="spacing-label">48px</div><div class="spacing-bar" style="width:192px"></div></div>
+      <div class="spacing-row"><div class="spacing-label">80px (section)</div><div class="spacing-bar" style="width:320px"></div></div>
+    </div>
+
+    <div class="token-group">
+      <div class="token-group-title">Scroll Viewport (vh-based, used by PostSection scroll-snap)</div>
+      <div class="spacing-row"><div class="spacing-label">52vh (half)</div><div class="spacing-bar" style="width:52%"></div></div>
+      <div class="spacing-row"><div class="spacing-label">55vh (threeFifths)</div><div class="spacing-bar" style="width:55%"></div></div>
+      <div class="spacing-row"><div class="spacing-label">65vh (full)</div><div class="spacing-bar" style="width:65%"></div></div>
+    </div>
+  </div>
+
+  <!-- EASINGS -->
+  <div class="section">
+    <div class="section-title">Easings (Functional Tokens)</div>
+    <p style="color:var(--text-tertiary);font-size:0.875rem;margin-bottom:16px">애니메이션 곡선은 시각 카탈로그가 아닌 코드로 표시한다. 컴포넌트는 <code style="font-family:var(--font-mono);color:var(--accent-700)">animation.*</code> import를 통해 사용한다.</p>
+    <div class="code-block"><span class="code-key">toast</span>: cubic-bezier(0.68, -0.55, 0.27, 1.55)  <span class="code-comment">// toast-in-out keyframe (overshoot)</span></div>
+    <div class="code-block"><span class="code-key">standard</span>: easeOut  <span class="code-comment">// 기본 진입/퇴장 (page, list, content)</span></div>
+    <div class="code-block"><span class="code-key">projectCard</span>: spring (stiffness 400, damping 17)  <span class="code-comment">// chipHover · 마이크로 인터랙션</span></div>
+  </div>
+
+  <!-- DURATIONS -->
+  <div class="section">
+    <div class="section-title">Durations</div>
+    <p style="color:var(--text-tertiary);font-size:0.875rem;margin-bottom:16px">Framer Motion <code style="font-family:var(--font-mono);color:var(--accent-700)">durations</code> 스케일 (초 단위). 토스트 노출 시간은 별도.</p>
+    <div class="code-block"><span class="code-key">instant</span>: 0.1s  <span class="code-comment">// press feedback</span></div>
+    <div class="code-block"><span class="code-key">micro</span>: 0.15s  <span class="code-comment">// micro-interaction</span></div>
+    <div class="code-block"><span class="code-key">fast</span>: 0.2s  <span class="code-comment">// quick hover, exit</span></div>
+    <div class="code-block"><span class="code-key">page</span>: 0.25s  <span class="code-comment">// page transition</span></div>
+    <div class="code-block"><span class="code-key">item</span>: 0.28s  <span class="code-comment">// item entrance (stagger)</span></div>
+    <div class="code-block"><span class="code-key">standard</span>: 0.3s  <span class="code-comment">// standard hover, shadow</span></div>
+    <div class="code-block"><span class="code-key">flip</span>: 0.7s  <span class="code-comment">// card flip (예외)</span></div>
+    <div class="code-block" style="border-color:var(--accent-500);background:var(--accent-50)"><span class="code-key">TOAST_VISIBLE_MS</span>: 3000ms  <span class="code-comment">// toast-in-out 총 지속 시간</span></div>
   </div>
 
 </div>

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,177 @@
+# Mogiyoon Design System
+
+이 문서는 mogiyoon 포트폴리오의 디자인 토큰을 어떻게 정의하고 사용하는지를 정리한 가이드임.
+
+---
+
+## 개요
+
+디자인 시스템은 다음 세 파일로 구성되며, 각 파일의 역할은 명확히 분리되어 있음.
+
+| 파일 | 역할 | 비고 |
+|---|---|---|
+| `src/design-tokens.ts` | **단일 진실 소스 (Single Source of Truth)** | 모든 색상/폰트/간격/반지름/그림자/애니메이션 값이 정의됨 |
+| `tailwind.config.ts` | **Tailwind 클래스 노출** | `design-tokens.ts`를 import하여 `theme.extend.*` 형태로 클래스 생성 |
+| `design-preview.html` | **시각 카탈로그** | 서버 없이 브라우저에서 열어 토큰을 시각적으로 확인 |
+
+### 절대 규칙
+
+1. **새 토큰을 추가할 때는 세 파일을 모두 업데이트해야 함.** 누락 시 디자인 일관성이 깨짐.
+2. `src/design-tokens.ts`가 변경되면 `tailwind.config.ts`와 `design-preview.html`이 동기화되어 있는지 확인할 것.
+3. 컴포넌트 코드는 토큰을 참조하거나 토큰에서 파생된 Tailwind 클래스를 사용해야 함. 임의 픽셀 값(`shadow-[7px_7px_...]`, `rounded-[1.4rem]` 등)은 가급적 토큰화함.
+
+---
+
+## 토큰 카테고리
+
+### Colors (`colors`)
+
+| 그룹 | 키 | 사용처 |
+|---|---|---|
+| `background.*` | white, slate50, slate100, slate200 | 페이지/카드 배경 |
+| `text.*` | primary, strong, secondary, meta, tertiary, muted | 본문/제목/메타 텍스트 |
+| `accent.*` | indigo50/100/500/600/700, violet400/500 | 브랜드 강조, CTA, 뱃지 |
+| `border.*` | default, strong | 구분선, 카드 테두리 |
+
+Tailwind 노출: `bg-surface`, `text-content`, `text-content-meta`, `bg-accent-500`, `border-line` 등.
+
+### Typography (`fonts`)
+
+| 키 | 폰트 | 사용처 |
+|---|---|---|
+| `body` | Noto Sans KR | 한글 본문 (기본) |
+| `latin` | Inter | 영문 본문 |
+| `display` | Caveat | 로고, 장식 헤딩만 |
+| `mono` | source-code-pro 외 | 코드/수치 표시 |
+
+Tailwind: `font-body`, `font-display`, `font-mono`, `font-latin`.
+
+### Spacing (`spacing`)
+
+| 키 | 값 | 사용처 |
+|---|---|---|
+| `section` | 5rem (80px) | 섹션 상단 패딩 (`pt-section`) |
+| `hairline` | 4px | 미세 패딩 (ProfileSection 등) |
+| `scrollViewport.half` | 52vh | PostSection 스크롤 스냅 (절반) |
+| `scrollViewport.threeFifths` | 55vh | PostSection 스크롤 스냅 (60%) |
+| `scrollViewport.full` | 65vh | PostSection 스크롤 스냅 (전체) |
+
+Tailwind 노출: `p-section`, `p-hairline`, `m-scroll-viewport-three-fifths`, `p-scroll-viewport-half`, `p-scroll-viewport-full`.
+(중첩 객체는 Tailwind 클래스로 노출되지 않으므로 평탄화한 키를 사용함.)
+
+### Radii (`radii`)
+
+세 그룹으로 구성됨.
+
+| 그룹 | 키 | 값 | 용도 |
+|---|---|---|---|
+| Semantic | `card` | 0.75rem (12px) | 일반 카드 |
+| Semantic | `modal` | 1rem (16px) | 모달 |
+| Semantic | `pill` | 9999px | 칩, 둥근 버튼 |
+| Generic | `md / lg / xl / 2xl / 3xl` | 6 / 8 / 12 / 16 / 24px | Tailwind 기본과 동일하게 미러링 |
+| App-specific | `cardSoft28` | 1.75rem (28px) | EducationCard, ProjectFlipPreviewCard |
+| App-specific | `cardChunky` | 3rem (48px) | PortfolioCard |
+| App-specific | `paperEdge` | 1.4rem (22.4px) | ResumePreviewPage |
+| App-specific | `paperEdgeLg` | 2rem (32px) | ResumePreviewPage |
+
+Tailwind: `rounded-card`, `rounded-modal`, `rounded-card-soft-28`, `rounded-paper-edge-lg` 등.
+
+### Shadows (`shadows`)
+
+다섯 그룹으로 구성됨.
+
+| 그룹 | 키 | 용도 |
+|---|---|---|
+| Generic | `sm / lg / xl / 2xl` | 일반 elevation (Tailwind 기본 미러) |
+| Brand glow | `glowAccent` | 인디고 외부 + 흰색 내부 글로우 (Vibe 뱃지) |
+| Brand glow | `glowAccentSm` | SVG 필터 그림자 (작은 글로우) |
+| Brand glow | `glowAccentXs` | 옅은 글로우 |
+| Decorative | `polaroidSm / Md / Lg` | 폴라로이드 사진 스타일 드롭 그림자 |
+| Decorative | `starGlow` | 별 화이트 글로우 (ShootingStar) |
+| Page-specific | `postCard` | 0 8px 24px / 0.28 alpha |
+| Page-specific | `postCardLg` | 0 10px 30px / 0.35 alpha |
+| Page-specific | `postWhiteGlow` | 흰색 글로우 (다크 배경 위) |
+| Page-specific | `resumePaper` | 이력서 종이 그림자 |
+
+Tailwind: `shadow-glow-accent`, `shadow-polaroid-lg`, `shadow-post-card`, `shadow-resume-paper` 등.
+
+### Easings (functional, code-only)
+
+| 키 | 값 | 사용처 |
+|---|---|---|
+| `toast` | `cubic-bezier(0.68, -0.55, 0.27, 1.55)` | toast-in-out (overshoot) |
+| `standard` | `easeOut` | 일반 진입/퇴장 (page, list, content) |
+| `projectCard` | spring(stiffness 400, damping 17) | chipHover, 마이크로 인터랙션 |
+
+`design-tokens.ts`의 `animation.*` 객체에 분산되어 있음. 시각화가 어려우므로 `design-preview.html`에서는 코드 블록으로만 표시.
+
+### Durations (`durations`)
+
+| 키 | 값 | 용도 |
+|---|---|---|
+| `instant` | 100ms | press feedback |
+| `micro` | 150ms | micro-interaction |
+| `fast` | 200ms | quick hover, exit |
+| `page` | 250ms | page transition |
+| `item` | 280ms | list item 진입 (stagger) |
+| `standard` | 300ms | 표준 hover, shadow |
+| `flip` | 700ms | 카드 플립 (예외) |
+
+`TOAST_VISIBLE_MS` (3000ms)는 토스트 노출 총 시간으로 별도 상수.
+
+---
+
+## 명명 규칙
+
+세 파일은 표현 방식이 다르므로 서로 다른 케이스를 사용함.
+
+| 위치 | 케이스 | 예시 |
+|---|---|---|
+| `src/design-tokens.ts` | `camelCase` | `glowAccent`, `cardSoft28`, `scrollViewport.threeFifths` |
+| `tailwind.config.ts` 노출 클래스 | `kebab-case` | `shadow-glow-accent`, `rounded-card-soft-28`, `p-scroll-viewport-three-fifths` |
+| `design-preview.html` CSS 변수 | `--kebab-case` (`--shadow-`, `--radius-`, `--spacing-` 접두) | `--shadow-glow-accent`, `--radius-card-soft-28` |
+
+세 표현은 1:1 대응되어야 함.
+
+---
+
+## 새 토큰 추가 절차
+
+신규 디자인 토큰이 필요하면 아래 3단계를 모두 수행함.
+
+1. **`src/design-tokens.ts`** — 적절한 카테고리 객체에 `camelCase` 키로 추가. 주석으로 단위(px/rem)와 사용처를 명시.
+2. **`tailwind.config.ts`** — 동일 토큰을 `theme.extend.*`에 `kebab-case` 키로 노출. import 누락 주의.
+3. **`design-preview.html`** — `:root` 블록에 CSS 변수로 추가하고, 해당 카테고리 섹션에 시각 미리보기를 추가.
+
+PR 시 위 세 파일이 같은 커밋에 포함되어 있어야 리뷰가 통과됨.
+
+---
+
+## 언제 토큰화할 것인가 (vs Arbitrary Value)
+
+**토큰화 대상**:
+- 동일하거나 유사한 값이 **2회 이상** 등장하는 경우
+- 의미 있는 디자인 결정(브랜드 색, 종이 질감, 카드 모서리 등)을 표현하는 값
+- 디자인 일관성을 위해 다른 컴포넌트에서도 재사용 가능성이 높은 값
+
+**그대로 두는 대상**:
+- 일회성 픽셀 미세 조정 (예: 특정 컴포넌트에서만 쓰이는 `top-[3px]`)
+- 디버깅용 / 임시 값
+- 외부 라이브러리 충돌 회피용 값
+
+판단이 모호하면 토큰화하는 쪽이 안전함. 토큰은 추가 비용이 거의 없고 추후 일관성 변경이 쉬움.
+
+---
+
+## 관련 문서 연계
+
+이 문서는 다음 두 에이전트/오케스트레이터의 기준 문서 역할을 함.
+
+- **`.claude/agents/designer.md`** — 디자이너 에이전트가 코드 리뷰 시 이 문서의 토큰 정의를 기준으로 일관성 위반을 판정함. 임의 값(`shadow-[...]`, `rounded-[...]` 등)이 발견되면 본 문서의 토큰 매핑을 참조해 권장 수정안을 제시함.
+- **`.claude/orchestrators/refactor-orchestrator.md`** (존재하는 경우) — 토큰 마이그레이션 리팩토링 시 본 문서의 매핑 표를 기준으로 변환을 수행함.
+
+---
+
+## 변경 이력
+
+- **2026-05-01** — 초기 작성. shadows / radii(app-specific) / spacing.scrollViewport / hairline 토큰 추가 (Step A).

--- a/src/design-tokens.ts
+++ b/src/design-tokens.ts
@@ -50,15 +50,58 @@ export const fonts = {
 // ─── Spacing ────────────────────────────────────────────
 
 export const spacing = {
-  section: '5rem', // 80px — pt-20
+  section: '5rem',     // 80px — pt-20
+  hairline: '4px',     // 4px — ProfileSection p-[4px]
+  scrollViewport: {
+    half: '52vh',          // PostSection p-[52vh]
+    threeFifths: '55vh',   // PostSection m-[55vh]
+    full: '65vh',          // PostSection p-[65vh]
+  },
 } as const;
 
 // ─── Border Radius ──────────────────────────────────────
 
 export const radii = {
-  card: '0.75rem',   // 12px — rounded-xl
-  modal: '1rem',     // 16px — rounded-2xl
-  pill: '9999px',    // rounded-full
+  // Existing semantic tokens
+  card: '0.75rem',         // 12px — rounded-xl
+  modal: '1rem',           // 16px — rounded-2xl
+  pill: '9999px',          // rounded-full
+  // Generic scale (mirrors design-preview.html CSS variables)
+  md: '6px',
+  lg: '8px',
+  xl: '12px',
+  '2xl': '16px',
+  '3xl': '24px',
+  // App-specific additions
+  cardSoft28: '1.75rem',   // 28px — EducationCard, ProjectFlipPreviewCard (~28.8px treated as same)
+  cardChunky: '3rem',      // 48px — PortfolioCard rounded-[3rem]
+  paperEdge: '1.4rem',     // 22.4px — ResumePreviewPage rounded-[1.4rem]
+  paperEdgeLg: '2rem',     // 32px — ResumePreviewPage rounded-[2rem]
+} as const;
+
+// ─── Shadows ────────────────────────────────────────────
+
+export const shadows = {
+  // Generic stack (mirrors Tailwind defaults; tokenized for design-preview parity)
+  sm: '0 1px 2px 0 rgb(0 0 0 / 0.05)',
+  lg: '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
+  xl: '0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)',
+  '2xl': '0 25px 50px -12px rgb(0 0 0 / 0.25)',
+  // Brand glow — indigo-500 base
+  glowAccent: '0 0 12px rgba(99,102,241,0.3), inset 0 1px 0 rgba(255,255,255,0.4)',
+  glowAccentSm: '0 0 2px rgba(99,102,241,0.6)',
+  glowAccentXs: '0 0 3px rgba(99,102,241,0.5)',
+  // Decorative — polaroid drop shadow stack
+  polaroidSm: '2px 2px 7px 1px rgba(0,0,0,0.5)',
+  polaroidMd: '5px 5px 5px 1px rgba(0,0,0,0.5)',
+  polaroidLg: '7px 7px 7px 1px rgba(0,0,0,0.5)',
+  // Decorative — celestial
+  starGlow: '0 0 10px #fff, 0 0 20px #fff',
+  // Page-specific
+  postCard: '0 8px 24px rgba(0,0,0,0.28)',         // PostSection (also covers 0.30 variant; Step B confirms)
+  postCardLg: '0 10px 30px rgba(0,0,0,0.35)',
+  postWhiteGlow: '0 0 15px rgba(255,255,255,0.2)',
+  resumePaper: '0 24px 80px rgba(15,23,42,0.18)',
 } as const;
 
 // ─── Keyframes & Animation ──────────────────────────────

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,5 @@
 import type { Config } from 'tailwindcss';
-import { colors, fonts, spacing, radii, keyframes, tailwindAnimation } from './src/design-tokens';
+import { colors, fonts, spacing, radii, shadows, keyframes, tailwindAnimation } from './src/design-tokens';
 
 export default {
   content: [
@@ -48,11 +48,48 @@ export default {
       },
       spacing: {
         section: spacing.section,
+        hairline: spacing.hairline,
+        'scroll-viewport-half': spacing.scrollViewport.half,
+        'scroll-viewport-three-fifths': spacing.scrollViewport.threeFifths,
+        'scroll-viewport-full': spacing.scrollViewport.full,
       },
       borderRadius: {
+        // Existing semantic tokens (preserved as-is)
         card: radii.card,
         modal: radii.modal,
         pill: radii.pill,
+        // Generic scale (Tailwind defaults already exist; these mirror the token source)
+        md: radii.md,
+        lg: radii.lg,
+        xl: radii.xl,
+        '2xl': radii['2xl'],
+        '3xl': radii['3xl'],
+        // App-specific
+        'card-soft-28': radii.cardSoft28,
+        'card-chunky': radii.cardChunky,
+        'paper-edge': radii.paperEdge,
+        'paper-edge-lg': radii.paperEdgeLg,
+      },
+      boxShadow: {
+        // Generic stack (mirrors Tailwind defaults but enables design-preview parity)
+        sm: shadows.sm,
+        lg: shadows.lg,
+        xl: shadows.xl,
+        '2xl': shadows['2xl'],
+        // Brand
+        'glow-accent': shadows.glowAccent,
+        'glow-accent-sm': shadows.glowAccentSm,
+        'glow-accent-xs': shadows.glowAccentXs,
+        // Decorative
+        'polaroid-sm': shadows.polaroidSm,
+        'polaroid-md': shadows.polaroidMd,
+        'polaroid-lg': shadows.polaroidLg,
+        'star-glow': shadows.starGlow,
+        // Page-specific
+        'post-card': shadows.postCard,
+        'post-card-lg': shadows.postCardLg,
+        'post-white-glow': shadows.postWhiteGlow,
+        'resume-paper': shadows.resumePaper,
       },
       keyframes,
       animation: tailwindAnimation,


### PR DESCRIPTION
## Summary
Step A of a two-PR design-system pass. Pure additive — no production source touched. Adds named tokens for the values that have been living as inline arbitrary Tailwind classes, so they have an authoritative home.

- **Shadows** (14): generic stack mirroring Tailwind defaults + brand glow trio + polaroid family + star glow + page-specific (postCard, postCardLg, postWhiteGlow, resumePaper)
- **Radii** (9): generic md/lg/xl/2xl/3xl + cardSoft28, cardChunky (3rem), paperEdge (1.4rem), paperEdgeLg (2rem)
- **Spacing** (4): hairline (4px) + scrollViewport.{half / threeFifths / full} for PostSection vh-based padding

[tailwind.config.ts](tailwind.config.ts) exposes them so callers can write `shadow-glow-accent` / `rounded-card-chunky` / `p-scroll-viewport-half`. [design-preview.html](design-preview.html) mirrors every new token as a CSS variable + visible swatch.

[docs/design-system.md](docs/design-system.md) (new, ~150 lines) is the official guide: three-file relationship, naming map (camelCase TS / kebab-case Tailwind / `--kebab` CSS), 3-step procedure for adding a token, and the token-vs-arbitrary heuristic.

## Follow-up (Step B, separate PR)
Migrate 13 arbitrary shadows + 6 arbitrary radii + 4 arbitrary spacings to these tokens. Will run after Step A merges so the migration PR is small and the diff is purely substitution.

## Test plan
- [x] `npm run build` passes (vite + tsc -b clean, verified by pre-push hook)
- [x] `npm test -- --run` passes (no production code changed)
- [x] `npm run lint` clean
- [ ] Manual: open `design-preview.html` in a browser and verify new shadow / radius / spacing swatches render

🤖 Generated with [Claude Code](https://claude.com/claude-code)