### PR TITLE
feat: sync IntroLine connector opacity with cards reveal

### DIFF
--- a/src/components/AboutMe/IntroLine.tsx
+++ b/src/components/AboutMe/IntroLine.tsx
@@ -217,7 +217,9 @@ const IntroPanel = ({
         <motion.div style={reveal.card01}>
           <NumberedCard {...card01} />
         </motion.div>
-        <Connector variant={connector} />
+        <motion.div style={reveal.card01}>
+          <Connector variant={connector} />
+        </motion.div>
         <motion.div style={reveal.card02}>
           <NumberedCard {...card02} />
         </motion.div>


### PR DESCRIPTION
## Summary
- About Me 섹션의 IntroLine 화살표/플러스 연결자가 카드와 동일한 reveal opacity를 따라가도록 `reveal.card01` motion 으로 감쌈
- 패널 활성 즉시 연결자만 단독으로 보이던 동작을 카드들의 페이드인 타이밍과 동기화

## Test plan
- [x] `npx vitest run src/components/AboutMe/IntroLine.test.tsx` 통과
- [x] pre-push 빌드 통과
- [ ] 브라우저에서 About Me 섹션 스크롤 시 화살표/플러스가 card01과 함께 fade-up 되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)