### PR TITLE
feat: refresh profile summary copy

### DIFF
--- a/public/data/resume-profile.en.json
+++ b/public/data/resume-profile.en.json
@@ -11,27 +11,28 @@
   },
   "photoPlaceholder": true,
   "intro": {
-    "line": "I'm Giyoon Noh, a full-stack engineer who keeps shipping through changing state.",
+    "line": "Developer who has solved repeated problems in learning and development through apps, extensions, and libraries",
     "bullets": [
       {
-        "text": "Experience from implementation to deployment through building an npm library, a teacher-exam quiz app, and a personal portfolio site",
-        "bold": ["npm library", "personal portfolio site", "implementation to deployment"],
+        "text": "Experience building and shipping a learning app, a Chrome extension, and an npm library, turning personal friction into reusable tools",
+        "bold": ["learning app", "Chrome extension", "npm library", "building and shipping", "reusable tools"],
         "links": [
-          { "text": "npm library", "url": "https://www.npmjs.com/package/mogiyoon-react-native-simple-grid" },
-          { "text": "personal portfolio site", "url": "https://mogiyoon.com" }
+          { "text": "learning app", "url": "https://play.google.com/store/apps/details?id=com.test_maker" },
+          { "text": "Chrome extension", "url": "https://chromewebstore.google.com/detail/boj-snippets-mogiyoon/omehpjefcoebjfcbiegjaaklfeelkpam" },
+          { "text": "npm library", "url": "https://www.npmjs.com/package/mogiyoon-react-native-simple-grid" }
         ]
       },
       {
-        "text": "Hands-on experience using AI across projects, from multimodal pipelines to YOLO and CNN-based workflows",
-        "bold": ["using AI across projects"]
+        "text": "Experience connecting multimodal and computer-vision features, plus AI-assisted testing and documentation workflows, to real product development",
+        "bold": ["multimodal and computer-vision features", "AI-assisted testing and documentation workflows", "real product development"]
       },
       {
-        "text": "Principle-driven problem solving built by following tough issues through to the end in both web and app projects",
-        "bold": ["Principle-driven problem solving"]
+        "text": "Performance improvement experience from tracing structure, data flow, and runtime issues, reducing main-screen load time from 2–3 seconds to 0.6 seconds and repeated API calls from dozens to 3–4",
+        "bold": ["2–3 seconds to 0.6 seconds", "dozens to 3–4", "Performance improvement experience"]
       },
       {
-        "text": "Creativity grounded in fundamentals, from a silver prize in an invention contest to a hackathon grand prize",
-        "bold": ["Creativity grounded in fundamentals"]
+        "text": "Verification and optimization experience from building a 20-suite, 217-test, 11-document system and reducing bundle size from 110MB to 80MB",
+        "bold": ["20-suite, 217-test, 11-document system", "110MB to 80MB", "Verification and optimization experience"]
       }
     ]
   },

--- a/public/data/resume-profile.json
+++ b/public/data/resume-profile.json
@@ -11,27 +11,28 @@
   },
   "photoPlaceholder": true,
   "intro": {
-    "line": "매 순간, 상태가 업데이트되는 풀스택 개발자 노기윤입니다.",
+    "line": "학습과 개발의 반복 문제를 앱, 확장 프로그램, 라이브러리로 해결해온 개발자",
     "bullets": [
       {
-        "text": "Npm 라이브러리, 임용 퀴즈 어플, 개인 홈페이지 등을 제작하며 얻은 구현부터 배포까지의 경험",
-        "bold": ["Npm 라이브러리", "개인 홈페이지", "구현부터 배포까지의 경험"],
+        "text": "학습 앱, Chrome 확장 프로그램, NPM 라이브러리를 직접 만들고 배포하며 개인의 불편을 다시 쓰이는 도구로 바꿔온 경험",
+        "bold": ["학습 앱", "Chrome 확장 프로그램", "NPM 라이브러리", "직접 만들고 배포", "다시 쓰이는 도구"],
         "links": [
-          { "text": "Npm 라이브러리", "url": "https://www.npmjs.com/package/mogiyoon-react-native-simple-grid" },
-          { "text": "개인 홈페이지", "url": "https://mogiyoon.com" }
+          { "text": "학습 앱", "url": "https://play.google.com/store/apps/details?id=com.test_maker" },
+          { "text": "Chrome 확장 프로그램", "url": "https://chromewebstore.google.com/detail/boj-snippets-mogiyoon/omehpjefcoebjfcbiegjaaklfeelkpam" },
+          { "text": "NPM 라이브러리", "url": "https://www.npmjs.com/package/mogiyoon-react-native-simple-grid" }
         ]
       },
       {
-        "text": "멀티모달 파이프라인부터 Yolo, CNN 등 프로젝트에서 다양하게 AI를 사용해본 경험",
-        "bold": ["AI를 사용해본 경험"]
+        "text": "멀티모달·컴퓨터 비전 기능과 AI 활용 테스트·문서화 워크플로를 실제 제품 개발에 연결해온 경험",
+        "bold": ["멀티모달·컴퓨터 비전 기능", "AI 활용 테스트·문서화 워크플로", "실제 제품 개발"]
       },
       {
-        "text": "웹, 앱 프로젝트에서 문제를 끝까지 파고들며 얻은 원리 기반 문제 해결력",
-        "bold": ["원리 기반 문제 해결력"]
+        "text": "구조·데이터 흐름·성능 이슈를 추적해 메인 로딩 2~3초를 0.6초로, 중복 API 호출을 수십 회에서 3~4회로 줄인 성능 개선 경험",
+        "bold": ["구조·데이터 흐름·성능 이슈", "메인 로딩 2~3초를 0.6초로", "중복 API 호출을 수십 회에서 3~4회로", "성능 개선 경험"]
       },
       {
-        "text": "발명 대회 은상부터 해커톤 대상까지, 기초와 개념 기반의 창의성",
-        "bold": ["창의성"]
+        "text": "20 suites·217 tests·문서 11건의 테스트 체계를 구축하고 번들 크기를 110MB에서 80MB로 줄인 검증·최적화 경험",
+        "bold": ["20 suites·217 tests·문서 11건", "번들 크기를 110MB에서 80MB로", "검증·최적화 경험"]
       }
     ]
   },


### PR DESCRIPTION
## Summary
- 이력서 프로필의 인트로 라인과 4개 불릿 카피를 갱신해 학습 앱·Chrome 확장·NPM 라이브러리 중심의 서사로 재구성
- 다중 모달/컴퓨터 비전, 성능 개선(2~3초→0.6초, 수십 회→3~4회), 테스트 체계(20 suites·217 tests·문서 11건) 및 번들 축소(110MB→80MB) 등 정량 성과 노출
- 한국어/영어 `resume-profile` JSON 동시 업데이트 및 링크/볼드 키워드 동기화

## Test plan
- [ ] `/resume` 미리보기에서 인트로 라인과 불릿 4개가 의도대로 렌더링되는지 확인
- [ ] 한국어/영어 토글 시 카피·볼드·링크가 모두 sync 되는지 확인
- [ ] 학습 앱·Chrome 확장·NPM 라이브러리 링크가 새 탭에서 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)