### PR TITLE
fix(prefetch): restore eager fetch for project lists and profile data

### DIFF
--- a/src/hooks/useCachedResource.test.tsx
+++ b/src/hooks/useCachedResource.test.tsx
@@ -43,4 +43,31 @@ describe('useCachedResource', () => {
     await waitFor(() => expect(first.result.current.data).toEqual({ value: 7 }));
     await waitFor(() => expect(second.result.current.data).toEqual({ value: 7 }));
   });
+
+  it('does NOT call loader on creation when eager option is false / omitted (lazy)', () => {
+    const loader = vi.fn(async () => ({ value: 1 }));
+    createCachedResource(loader);
+    expect(loader).not.toHaveBeenCalled();
+  });
+
+  it('calls loader immediately on creation when eager: true (prefetch)', () => {
+    const loader = vi.fn(async () => ({ value: 1 }));
+    createCachedResource(loader, { eager: true });
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  it('eager-loaded resource is cached and reused by useCachedResource without re-fetch', async () => {
+    const loader = vi.fn(async () => ({ value: 99 }));
+    const resource = createCachedResource(loader, { eager: true });
+
+    // Wait for eager load to complete.
+    await waitFor(() => expect(resource.getCached()).toEqual({ value: 99 }));
+
+    const hook = renderHook(() => useCachedResource(resource));
+
+    // Already cached → no loading flash, data available immediately.
+    expect(hook.result.current.isLoading).toBe(false);
+    expect(hook.result.current.data).toEqual({ value: 99 });
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/hooks/useCachedResource.ts
+++ b/src/hooks/useCachedResource.ts
@@ -5,13 +5,28 @@ export interface CachedResource<T> {
   load: () => Promise<T | null>;
 }
 
+export interface CreateCachedResourceOptions {
+  /**
+   * true 면 createCachedResource 호출 시점(모듈 로드 시점)에 즉시 load() 를 호출해
+   * 사용자가 화면을 클릭하기 전에 fetch 를 시작한다.
+   *
+   * 리팩토링 이전 `useProjectLists` / ProfileSection prefetch 가 동일한 효과를
+   * 모듈 최상단의 즉시 실행 Promise 로 얻고 있었기 때문에, lazy 동작으로 회귀하지
+   * 않도록 정적 JSON 리소스에는 보통 true 를 지정한다.
+   */
+  eager?: boolean;
+}
+
 /**
  * 모듈 단위로 한 번만 로드하고 재사용할 리소스를 만든다.
  *
  * 정적 JSON처럼 여러 화면/훅에서 읽지만 요청은 한 번만 날리고 싶은 경우에 사용한다.
+ * `eager: true` 옵션을 주면 모듈 로드 시점에 fetch 가 즉시 시작된다 (탭 클릭 전에
+ * 미리 받아두는 prefetch 효과). 기본값은 false (lazy).
  */
 export const createCachedResource = <T,>(
   loader: () => Promise<T>,
+  options: CreateCachedResourceOptions = {},
 ): CachedResource<T> => {
   let cached: T | null = null;
   let pending: Promise<T | null> | null = null;
@@ -36,10 +51,16 @@ export const createCachedResource = <T,>(
     return pending;
   };
 
-  return {
+  const resource: CachedResource<T> = {
     getCached: () => cached,
     load,
   };
+
+  if (options.eager) {
+    void load();
+  }
+
+  return resource;
 };
 
 /**

--- a/src/hooks/useProjectLists.ts
+++ b/src/hooks/useProjectLists.ts
@@ -8,14 +8,17 @@ type PrefetchedLists = {
     preparing: PreparingProjectData[];
 };
 
-const projectListsResource = createCachedResource<PrefetchedLists>(async () => {
-    const [projects, preparing] = await Promise.all([
-        fetchJson<ProjectSummary[]>('/data/projects-list.json'),
-        fetchJson<PreparingProjectData[]>('/data/preparing-projects-list.json'),
-    ]);
+const projectListsResource = createCachedResource<PrefetchedLists>(
+    async () => {
+        const [projects, preparing] = await Promise.all([
+            fetchJson<ProjectSummary[]>('/data/projects-list.json'),
+            fetchJson<PreparingProjectData[]>('/data/preparing-projects-list.json'),
+        ]);
 
-    return { projects, preparing };
-});
+        return { projects, preparing };
+    },
+    { eager: true },
+);
 
 export const useProjectLists = () => {
     const { data, isLoading } = useCachedResource(projectListsResource);

--- a/src/sections/home/ProfileSection/prefetch.ts
+++ b/src/sections/home/ProfileSection/prefetch.ts
@@ -9,6 +9,7 @@ import { fetchJson } from '../../../utils/fetchJson';
  * dataResource 는 fetch 완료값을 모듈 단위로 캐시하므로 ProfileSection 재방문 시
  * 다시 요청하지 않고 즉시 재사용할 수 있다.
  */
-export const dataResource = createCachedResource<ProfileData>(() =>
-  fetchJson<ProfileData>('/data/introduction.json'),
+export const dataResource = createCachedResource<ProfileData>(
+  () => fetchJson<ProfileData>('/data/introduction.json'),
+  { eager: true },
 );


### PR DESCRIPTION
## Summary
PR #81 의 `createCachedResource` 도입이 fetch 동작을 **eager → lazy** 로 바꿔서, 프로젝트 섹션 카드가 가끔 표시되지 않는 회귀를 일으킴 (\"프로젝트만 떠 있을 때가 있음\"). `eager` 옵션 추가로 리팩토링 이전 동작 복원.

## 원인
- **리팩토링 이전**: 모듈 최상단의 \`fetch(...).then(...)\` 가 즉시 실행되어 사용자가 탭을 클릭할 때 보통 캐시 hit
- **리팩토링 이후**: \`createCachedResource\` 는 \`load()\` 호출 전까지 fetch 미실행 (lazy)
- **결과**: ProjectsSection 마운트 시점에 fetch 가 비로소 시작되고, 카드 마운트 + \`useLayoutEffect\` ref 측정 + \`projectCardOffsetsReady\` 진입 체인이 React StrictMode 의 mount/unmount + 비동기 데이터 도착과 맞물려 가끔 \`projectCardOffsetsReady\` 가 false 에 머물러 카드가 \`opacity:0\` 으로 보임

## 수정
\`createCachedResource\` 에 \`eager?: boolean\` 옵션 추가. \`true\` 면 모듈 로드 시점에 즉시 \`load()\` 호출.

\`\`\`ts
// Before
const resource = createCachedResource(loader);  // ← lazy

// After
const resource = createCachedResource(loader, { eager: true });  // ← eager, restores old behavior
\`\`\`

### 적용 사용처
- \`src/hooks/useProjectLists.ts\` (홈 프로젝트 목록)
- \`src/sections/home/ProfileSection/prefetch.ts\` (이력서 데이터)

## Test plan
- [x] \`useCachedResource.test.tsx\` 에 eager 동작 검증 3개 추가:
  - eager 미지정 시 loader 미호출 (lazy)
  - \`eager: true\` 시 생성 즉시 loader 호출
  - eager 로 캐시된 리소스는 hook 마운트 시 즉시 데이터 반환 (loading 플래시 없음)
- [x] 전체 \`npm test\` — 336 통과 (+3)
- [x] \`npm run build\` — 정상
- [x] \`npx tsc -b\` — 타입 검사 통과
- [ ] dev 서버에서 Projects 탭 클릭 시 카드가 즉시 표시되는지 확인
- [ ] 이력서 페이지 진입 시 데이터 로딩 플래시가 안 보이는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)