### PR TITLE
fix(about): block Switch clicks while faded out

### DIFF
--- a/src/components/AboutMe/Switch.tsx
+++ b/src/components/AboutMe/Switch.tsx
@@ -1,5 +1,5 @@
 // Switch.tsx
-import { motion, MotionValue } from 'framer-motion';
+import { motion, MotionValue, useTransform } from 'framer-motion';
 import { animation } from '../../design-tokens';
 
 interface SwitchProps {
@@ -9,9 +9,11 @@ interface SwitchProps {
 }
 
 export const Switch: React.FC<SwitchProps> = ({ onClick, opacity, isSwitchedOn }) => {
+  const pointerEvents = useTransform(opacity, (v) => (v > 0.05 ? 'auto' : 'none'));
+
   return (
     <motion.div
-      style={{ opacity }}
+      style={{ opacity, pointerEvents }}
       className="fixed bottom-10 left-1/2 -translate-x-1/2 z-50 flex flex-col items-center gap-2"
     >
       <button


### PR DESCRIPTION
## Summary
- `MainPhrase5to8`의 `Switch`가 `fixed` 요소이고 가시성을 opacity 만으로 제어해, 화면에서 안 보이는 상태에서도 다른 스크롤 구간 하단의 클릭을 흡수해 토글되던 문제가 있었음.
- 기존 `opacity` MotionValue 로부터 `pointerEvents` MotionValue 를 파생해 함께 적용. opacity 가 5% 이하로 떨어지면 스위치가 비인터랙티브가 되도록 함.

## Test plan
- [ ] About 섹션에서 `MainPhrase5to8` 구간으로 스크롤했을 때 스위치가 정상 토글되는지 확인
- [ ] 스위치가 아직 페이드인 되지 않은 위쪽 스크롤 구간에서 스위치 자리(화면 하단 중앙)를 클릭해도 토글되지 않는지 확인
- [ ] 페이드 아웃이 끝난 아래쪽 스크롤 구간에서도 동일하게 클릭이 통과하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)