### PR TITLE
fix(home): trigger project grid entrance without viewport gate

### DIFF
--- a/src/hooks/useProjectGridEntrance.test.tsx
+++ b/src/hooks/useProjectGridEntrance.test.tsx
@@ -151,7 +151,9 @@ describe('useProjectGridEntrance', () => {
         expect(result.current.hasPlayedProjectEntrance).toBe(true);
     });
 
-    it('does not play entrance when grid is not in view', async () => {
+    it('plays entrance even when the grid is below the fold (mobile layout)', async () => {
+        // 사이드바가 위 / 그리드가 아래에 쌓이는 모바일 레이아웃에서는 그리드가 초기 viewport 밖에 있어
+        // useInView 게이트가 켜져 있으면 카드들이 스크롤 전까지 invisible 인 채로 머무는 버그가 있었음.
         inViewState.current = false;
         const projects = [buildProject('alpha'), buildProject('beta')];
 
@@ -171,7 +173,7 @@ describe('useProjectGridEntrance', () => {
         });
 
         expect(result.current.projectCardOffsetsReady).toBe(true);
-        expect(result.current.hasPlayedProjectEntrance).toBe(false);
+        expect(result.current.hasPlayedProjectEntrance).toBe(true);
     });
 
     it('showAiDevKit becomes true after a delay scaled by projects.length once entrance has played', async () => {

--- a/src/hooks/useProjectGridEntrance.ts
+++ b/src/hooks/useProjectGridEntrance.ts
@@ -1,5 +1,4 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { useInView } from 'framer-motion';
 
 import { easings } from '../design-tokens';
 import type { ProjectSummary } from '../types';
@@ -28,10 +27,6 @@ export const useProjectGridEntrance = ({
 }: UseProjectGridEntranceArgs) => {
     const projectsGridRef = useRef<HTMLDivElement | null>(null);
     const projectCardRefs = useRef<Record<string, HTMLDivElement | null>>({});
-    const isProjectsGridInView = useInView(projectsGridRef, {
-        once: true,
-        amount: 0.18,
-    });
 
     const [projectCardOffsets, setProjectCardOffsets] = useState<Record<string, ProjectCardOffset>>({});
     const [hasPlayedProjectEntrance, setHasPlayedProjectEntrance] = useState(false);
@@ -81,8 +76,11 @@ export const useProjectGridEntrance = ({
     const projectCardOffsetsReady =
         projects.length > 0 && projects.every((project) => Boolean(projectCardOffsets[project.id]));
 
+    // offsets 가 준비되는 즉시 entrance 애니메이션을 발화한다.
+    // 모바일 레이아웃에서 사이드바가 위 / 그리드가 아래에 쌓여 그리드가 초기 fold 아래에 있을 때,
+    // viewport 진입을 게이트로 두면 사용자가 스크롤하기 전까지 카드들이 opacity: 0 인 채 보이지 않는다.
     useEffect(() => {
-        if (!projectCardOffsetsReady || hasPlayedProjectEntrance || !isProjectsGridInView) return;
+        if (!projectCardOffsetsReady || hasPlayedProjectEntrance) return;
 
         const animationFrame = window.requestAnimationFrame(() => {
             setHasPlayedProjectEntrance(true);
@@ -91,7 +89,7 @@ export const useProjectGridEntrance = ({
         return () => {
             window.cancelAnimationFrame(animationFrame);
         };
-    }, [projectCardOffsetsReady, hasPlayedProjectEntrance, isProjectsGridInView]);
+    }, [projectCardOffsetsReady, hasPlayedProjectEntrance]);
 
     useEffect(() => {
         if (!hasPlayedProjectEntrance || showAiDevKit) return;


### PR DESCRIPTION
## Summary
모바일에서 프로젝트 탭 진입 시 카드가 보이지 않고 스크롤해야 등장하던 문제를 수정.

## 원인
`useProjectGridEntrance` 의 entrance 트리거가 `useInView(grid, { amount: 0.18, once: true })` 로 게이트되어 있어, 모바일 레이아웃(사이드바 위 / 그리드 아래로 stack)에서 그리드가 초기 fold 아래에 있을 때 카드들이 cluster variant(`opacity: 0`, `blur(12px)`) 인 채 머물러 있음. 사이드바 텍스트만 노출되고, 사용자가 스크롤해서 그리드가 viewport 에 18% 이상 들어와야 entrance 가 발화.

## 해결
viewport 게이트를 제거하고 `projectCardOffsetsReady` 가 true 가 되는 즉시 entrance 를 트리거. 데스크톱(side-by-side 레이아웃)에서는 그리드가 첫 화면에 보이는 시점에 즉시 발화하므로 체감 동일.

## Test plan
- [ ] 모바일 viewport (Chrome DevTools) 에서 프로젝트 탭 진입 시 카드가 즉시 등장 애니메이션과 함께 보이는지 확인
- [ ] 데스크톱에서 entrance 애니메이션이 기존과 동일하게 재생되는지 확인
- [x] `useProjectGridEntrance` 단위 테스트 통과 (below-the-fold 케이스도 entrance 발화)

🤖 Generated with [Claude Code](https://claude.com/claude-code)