### PR TITLE
fix(timeline): preserve tab indentation in TimelineStep body

### DIFF
--- a/src/components/primitives/TimelineStep.tsx
+++ b/src/components/primitives/TimelineStep.tsx
@@ -50,7 +50,7 @@ export const TimelineSolidStep: React.FC<{
     <div className={`absolute -left-6 top-hairline w-3 h-3 rounded-full ${SOLID_DOT_SHADE[shade]}`} />
     <span className={`${EYEBROW_BASE} text-content-tertiary mb-2`}>{label}</span>
     <div className="rounded-card border border-line bg-surface-subtle px-4 py-3">
-      <p className="text-sm text-content-secondary leading-relaxed whitespace-pre-line">
+      <p className="text-sm text-content-secondary leading-relaxed whitespace-pre-wrap">
         {children}
       </p>
     </div>
@@ -60,7 +60,7 @@ export const TimelineSolidStep: React.FC<{
 export const TimelineFinalStep: React.FC<{
   label: StepLabel;
   children: StepContent;
-  /** 본문에 `whitespace-pre-line` 적용 여부 (멀티라인 description 일 때 true) */
+  /** 본문에 `whitespace-pre-wrap` 적용 여부 (멀티라인 description 일 때 true) */
   preserveLineBreaks?: boolean;
 }> = ({ label, children, preserveLineBreaks = false }) => (
   <div className="relative">
@@ -69,7 +69,7 @@ export const TimelineFinalStep: React.FC<{
     <div className="rounded-card bg-slate-900 px-4 py-3">
       <p
         className={`text-sm font-semibold text-white leading-relaxed ${
-          preserveLineBreaks ? 'whitespace-pre-line' : ''
+          preserveLineBreaks ? 'whitespace-pre-wrap' : ''
         }`.trim()}
       >
         {children}


### PR DESCRIPTION
## Summary
`TimelineSolidStep` / `TimelineFinalStep` 본문이 `whitespace-pre-line` 을 사용해 탭/스페이스 시퀀스가 단일 공백으로 collapse 되던 버그. `whitespace-pre-wrap` 으로 교체.

## 원인
CSS 사양상 `pre-line`: 줄바꿈 보존, 탭/스페이스 시퀀스는 단일 공백으로 collapse. 일부 프로젝트 데이터(recho 등) 의 해결 본문이 \`\\n\\t\\t-\` 형태의 중첩 bullet 들여쓰기를 가지고 있어, 탭이 사라지면서 들여쓰기 계층이 무너졌음.

## 해결
`whitespace-pre-wrap` — 줄바꿈 + 탭 + 스페이스 모두 보존하면서 줄바꿈 wrap. `TimelineInitialStep` 은 `bodyClassName` 으로 호출자가 직접 지정하므로 영향 없음.

## Stacked on
[#88](https://github.com/mogiyoon/mogiyoon/pull/88) (refactor/promote-timeline-step)

## Test plan
- [ ] recho 프로젝트 상세 페이지에서 \"해결\" 본문의 중첩 bullet 들여쓰기가 보이는지 확인
- [x] `npm run build` (pre-push 훅 통과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)