### PR TITLE
feat(hero): fade scroll cue based on scroll position

### DIFF
--- a/src/components/AboutMe/HeroHook.tsx
+++ b/src/components/AboutMe/HeroHook.tsx
@@ -1,8 +1,10 @@
-import { motion } from "framer-motion";
+import { motion, useScroll, useTransform } from "framer-motion";
 import { useTranslation } from "react-i18next";
 
 export const HeroHook: React.FC = () => {
   const { t } = useTranslation();
+  const { scrollY } = useScroll();
+  const scrollCueOpacity = useTransform(scrollY, [0, 200], [1, 0]);
 
   return (
     <section className="relative h-screen w-full bg-white overflow-hidden">
@@ -47,11 +49,10 @@ export const HeroHook: React.FC = () => {
 
       </div>
 
-      {/* Scroll cue: text above the ▼, centered at bottom */}
+      {/* Scroll cue: text above the ▼, centered at bottom.
+          스크롤할수록 자연스럽게 opacity 감소 (0 → 200px). */}
       <motion.div
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ duration: 0.4, delay: 0.85 }}
+        style={{ opacity: scrollCueOpacity }}
         className="absolute bottom-8 left-1/2 -translate-x-1/2 flex flex-col items-center gap-1.5"
       >
         <span className="font-latin text-xs font-medium text-content-meta">


### PR DESCRIPTION
## Summary
About 페이지 첫 화면 하단의 \"스크롤해서 시작\" cue 가 사용자가 스크롤하면 자연스럽게 사라지도록 변경.

## 변경
- `useScroll` + `useTransform` 으로 `scrollY` 를 [0, 200]px 구간에서 opacity [1, 0] 으로 매핑
- mount 시 fade-in 은 제거 (scroll 기반 opacity 가 항상 적용되도록 단순화)

## Test plan
- [ ] About 첫 화면 진입 시 cue 가 보이는지 확인
- [ ] 스크롤할수록 자연스럽게 fade-out 되는지 확인 (200px 내에서 완전 투명)

🤖 Generated with [Claude Code](https://claude.com/claude-code)