### PR TITLE
fix(about): close the seam between HeroHook and IntroLine

### DIFF
--- a/src/components/AboutMe/IntroLine.tsx
+++ b/src/components/AboutMe/IntroLine.tsx
@@ -137,7 +137,7 @@ export const IntroLine: React.FC = () => {
   };
 
   return (
-    <section ref={targetRef} className="relative h-[1000vh]">
+    <section ref={targetRef} className="relative h-[1000vh] bg-white">
       <div className="sticky top-0 h-screen w-full overflow-hidden bg-white">
         <PanelLayer
           opacity={startPanelOpacity}

--- a/src/sections/home/AboutSection.tsx
+++ b/src/sections/home/AboutSection.tsx
@@ -8,7 +8,10 @@ import { DeveloperIntro } from '../../components/AboutMe/DeveloperIntro';
 
 const AboutSection: React.FC = () => {
   return (
-    <div className="w-full">
+    // html.about-active 의 orange→white gradient (index.css) 가 섹션 간 sub-pixel
+    // 경계로 새지 않도록, About 컨텐츠 컨테이너 자체에 흰 배경을 깐다.
+    // 각 섹션이 자체 bg 를 가지므로 wrapper 의 white 는 그대로 가려진다.
+    <div className="w-full bg-white">
       <HeroHook/>
       <IntroLine/>
       <MainPhrase1to4/>


### PR DESCRIPTION
## Summary
About 페이지 첫 화면(HeroHook)과 두 번째 화면(IntroLine) 사이에 보이던 얇은 가로 선 제거.

## 원인
`html.about-active` 가 `linear-gradient(#c2410c 0%, #ffffff 100%)` 배경을 깔고 있는데 (src/index.css), HeroHook 은 `bg-white` 이지만 IntroLine 의 outer section 은 투명. 두 섹션 경계(100vh)에서 sub-pixel 렌더링 차이로 gradient 의 orange 부분이 잠깐 보임.

## 해결
IntroLine 의 outer section 에 `bg-white` 추가 — 경계 영역이 완전히 불투명해져 gradient 가 새지 않음.

## Test plan
- [ ] About 페이지에서 HeroHook → IntroLine 경계가 매끄럽게 이어지는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)