### PR TITLE
feat(project): embed live react-stable-timeline demo in its project page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
+        "@mogiyoon/react-stable-timeline": "^0.2.2",
         "@prerenderer/renderer-puppeteer": "^1.2.4",
         "@prerenderer/rollup-plugin": "^0.3.12",
         "framer-motion": "^12.23.12",
@@ -1061,6 +1062,19 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mogiyoon/react-stable-timeline": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@mogiyoon/react-stable-timeline/-/react-stable-timeline-0.2.2.tgz",
+      "integrity": "sha512-P4XMKLCLXJD1n2NGrKpZTdxPpc5ynfS2rwzviTnccayh1B2yb4/75ZGesNu0pjYcYXtas0/Abseyksxp3++Bcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
-        "@mogiyoon/react-stable-timeline": "^0.2.2",
+        "@mogiyoon/react-stable-timeline": "^0.3.0",
         "@prerenderer/renderer-puppeteer": "^1.2.4",
         "@prerenderer/rollup-plugin": "^0.3.12",
         "framer-motion": "^12.23.12",
@@ -1065,9 +1065,9 @@
       }
     },
     "node_modules/@mogiyoon/react-stable-timeline": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@mogiyoon/react-stable-timeline/-/react-stable-timeline-0.2.2.tgz",
-      "integrity": "sha512-P4XMKLCLXJD1n2NGrKpZTdxPpc5ynfS2rwzviTnccayh1B2yb4/75ZGesNu0pjYcYXtas0/Abseyksxp3++Bcw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@mogiyoon/react-stable-timeline/-/react-stable-timeline-0.3.0.tgz",
+      "integrity": "sha512-sxfoxd1JorrLtkH+ENT6DqYNrPHuSrSolS+l2qj3053WoFMyWoht+O7tQwtPdHoQ1lE0HsjBHOiCWfa7v6KqdA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
-    "@mogiyoon/react-stable-timeline": "^0.2.2",
+    "@mogiyoon/react-stable-timeline": "^0.3.0",
     "@prerenderer/renderer-puppeteer": "^1.2.4",
     "@prerenderer/rollup-plugin": "^0.3.12",
     "framer-motion": "^12.23.12",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
+    "@mogiyoon/react-stable-timeline": "^0.2.2",
     "@prerenderer/renderer-puppeteer": "^1.2.4",
     "@prerenderer/rollup-plugin": "^0.3.12",
     "framer-motion": "^12.23.12",

--- a/src/components/ReactStableTimelineDemo.tsx
+++ b/src/components/ReactStableTimelineDemo.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Timeline, type TimelineItem } from '@mogiyoon/react-stable-timeline';
+
+const ms = (iso: string) => new Date(iso).getTime();
+
+// mogiyoon 포트폴리오 프로젝트들을 실제 기간 그대로 라이브러리에 입력한 라이브 데모.
+// GIF 대신 라이브러리 자체를 보여줌으로써 행 안정성·라벨 폭 측정 동작을
+// 사용자가 직접 줌·팬으로 확인할 수 있다.
+const demoItems: TimelineItem[] = [
+    { id: 'teacher-test', label: 'Teacher Test', start: ms('2024-01-01'), end: ms('2024-02-28') },
+    { id: 'test-maker', label: 'Test Maker', start: ms('2024-11-01'), end: ms('2025-02-28') },
+    { id: 'mrnsg', label: 'mrnsg', start: ms('2025-01-01'), end: ms('2025-01-31') },
+    { id: 'recho', label: 'Recho', start: ms('2025-06-01'), end: ms('2025-07-31') },
+    { id: 'seoul-meari', label: 'Seoul Meari', start: ms('2025-08-01'), end: ms('2025-09-30') },
+    { id: 'boj-snippets', label: 'BOJ Snippets', start: ms('2026-04-01'), end: ms('2026-04-30') },
+    { id: 'react-stable-timeline', label: '@mogiyoon/react-stable-timeline', start: ms('2026-05-01'), end: ms('2026-05-31') },
+    { id: 'storytect', label: 'Storytect', start: ms('2026-05-01'), end: ms('2026-05-31') },
+];
+
+const ReactStableTimelineDemo: React.FC = () => (
+    <div className="w-full rounded-modal bg-white shadow-xl border border-line overflow-hidden">
+        <Timeline
+            items={demoItems}
+            accentColor="#6366f1"
+            style={{ height: 360 }}
+        />
+    </div>
+);
+
+export default ReactStableTimelineDemo;

--- a/src/components/TotalSummaryComponent.tsx
+++ b/src/components/TotalSummaryComponent.tsx
@@ -2,6 +2,7 @@ import type { ProjectData, SummaryPart, SummaryTextCategory } from "../types";
 import React from "react";
 import type { TFunction } from "i18next";
 import ToastNotification from "./ToastNotification";
+import ReactStableTimelineDemo from "./ReactStableTimelineDemo";
 import { Chip } from "./primitives/Chip";
 import ExternalLink from "./primitives/ExternalLink";
 import InfoCell from "./primitives/InfoCell";
@@ -15,6 +16,7 @@ import { useCopyToClipboardWithToast } from "../hooks/useCopyToClipboardWithToas
 interface TotalSummaryComponentProps {
   project: ProjectData;
   t: TFunction;
+  projectId?: string;
 }
 
 type CategorizedTextPart = Extract<SummaryPart, { type: "text" }> & {
@@ -214,7 +216,7 @@ const LinkButton: React.FC<{ href: string; label: string; primary?: boolean }> =
 );
 
 // ── Main component ─────────────────────────────────────────────────────────────
-const TotalSummaryComponent: React.FC<TotalSummaryComponentProps> = ({ project, t }) => {
+const TotalSummaryComponent: React.FC<TotalSummaryComponentProps> = ({ project, t, projectId }) => {
   const { toast, copy } = useCopyToClipboardWithToast();
 
   const handleCopyLink = (sectionId: string) => {
@@ -233,6 +235,13 @@ const TotalSummaryComponent: React.FC<TotalSummaryComponentProps> = ({ project, 
 
         {/* ── Overview ── */}
         <section className="mb-10">
+          {/* Live demo: 라이브러리 프로젝트는 개요 칸 제일 위에 실제 라이브러리를 임베드 */}
+          {projectId === "react-stable-timeline" && (
+            <div className="mb-6">
+              <ReactStableTimelineDemo />
+            </div>
+          )}
+
           <p className="text-xs font-semibold uppercase tracking-widest text-content-muted mb-5">
             {t("projectDetail.overview", { ns: "common" })}
           </p>

--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -5,7 +5,6 @@ import { motion } from 'framer-motion';
 
 import type { ProjectData } from '../types';
 import TotalSummaryComponent from '../components/TotalSummaryComponent';
-import ReactStableTimelineDemo from '../components/ReactStableTimelineDemo';
 import Seo from '../components/Seo';
 import { SEO_COPY, pickSeoLocale } from '../seo-copy';
 import { animation } from '../design-tokens';
@@ -138,31 +137,25 @@ const ProjectDetailPage: React.FC = () => {
             )}
           </header>
 
-          {/* Demo: 라이브러리 프로젝트는 GIF 대신 실제 라이브러리를 임베드해 라이브 데모를 노출 */}
-          {projectId === 'react-stable-timeline' ? (
-            <section className="mb-14">
-              <ReactStableTimelineDemo />
-            </section>
-          ) : (
-            <section className="mb-14 flex justify-center">
-              <div className={`w-full ${gifMaxW}`}>
-                {!isLoaded && (
-                  <div className={`rounded-modal bg-slate-200 animate-pulse w-full ${gifType === 'mobile' ? 'h-[444px]' : 'aspect-video'}`} />
-                )}
-                <img
-                  src={project.demoGifSrc}
-                  alt={`${t(project.title)} Demo`}
-                  className={`w-full rounded-modal shadow-xl border border-line transition-opacity duration-500 ${isLoaded ? 'opacity-100' : 'opacity-0 absolute'}`}
-                  onLoad={() => setIsLoaded(true)}
-                  onError={handleImageError}
-                />
-              </div>
-            </section>
-          )}
+          {/* Demo: 모든 프로젝트는 도입부에 GIF 데모를 노출 */}
+          <section className="mb-14 flex justify-center">
+            <div className={`w-full ${gifMaxW}`}>
+              {!isLoaded && (
+                <div className={`rounded-modal bg-slate-200 animate-pulse w-full ${gifType === 'mobile' ? 'h-[444px]' : 'aspect-video'}`} />
+              )}
+              <img
+                src={project.demoGifSrc}
+                alt={`${t(project.title)} Demo`}
+                className={`w-full rounded-modal shadow-xl border border-line transition-opacity duration-500 ${isLoaded ? 'opacity-100' : 'opacity-0 absolute'}`}
+                onLoad={() => setIsLoaded(true)}
+                onError={handleImageError}
+              />
+            </div>
+          </section>
 
           {/* Content */}
           <div className="bg-surface rounded-3xl shadow-sm border border-line overflow-hidden">
-            <TotalSummaryComponent project={project} t={t} />
+            <TotalSummaryComponent project={project} t={t} projectId={projectId} />
 
             {/* License */}
             <div className="px-6 sm:px-10 py-8 border-t border-line">

--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -5,6 +5,7 @@ import { motion } from 'framer-motion';
 
 import type { ProjectData } from '../types';
 import TotalSummaryComponent from '../components/TotalSummaryComponent';
+import ReactStableTimelineDemo from '../components/ReactStableTimelineDemo';
 import Seo from '../components/Seo';
 import { SEO_COPY, pickSeoLocale } from '../seo-copy';
 import { animation } from '../design-tokens';
@@ -137,21 +138,27 @@ const ProjectDetailPage: React.FC = () => {
             )}
           </header>
 
-          {/* Demo GIF */}
-          <section className="mb-14 flex justify-center">
-            <div className={`w-full ${gifMaxW}`}>
-              {!isLoaded && (
-                <div className={`rounded-modal bg-slate-200 animate-pulse w-full ${gifType === 'mobile' ? 'h-[444px]' : 'aspect-video'}`} />
-              )}
-              <img
-                src={project.demoGifSrc}
-                alt={`${t(project.title)} Demo`}
-                className={`w-full rounded-modal shadow-xl border border-line transition-opacity duration-500 ${isLoaded ? 'opacity-100' : 'opacity-0 absolute'}`}
-                onLoad={() => setIsLoaded(true)}
-                onError={handleImageError}
-              />
-            </div>
-          </section>
+          {/* Demo: 라이브러리 프로젝트는 GIF 대신 실제 라이브러리를 임베드해 라이브 데모를 노출 */}
+          {projectId === 'react-stable-timeline' ? (
+            <section className="mb-14">
+              <ReactStableTimelineDemo />
+            </section>
+          ) : (
+            <section className="mb-14 flex justify-center">
+              <div className={`w-full ${gifMaxW}`}>
+                {!isLoaded && (
+                  <div className={`rounded-modal bg-slate-200 animate-pulse w-full ${gifType === 'mobile' ? 'h-[444px]' : 'aspect-video'}`} />
+                )}
+                <img
+                  src={project.demoGifSrc}
+                  alt={`${t(project.title)} Demo`}
+                  className={`w-full rounded-modal shadow-xl border border-line transition-opacity duration-500 ${isLoaded ? 'opacity-100' : 'opacity-0 absolute'}`}
+                  onLoad={() => setIsLoaded(true)}
+                  onError={handleImageError}
+                />
+              </div>
+            </section>
+          )}
 
           {/* Content */}
           <div className="bg-surface rounded-3xl shadow-sm border border-line overflow-hidden">


### PR DESCRIPTION
## Summary
react-stable-timeline 프로젝트 상세 페이지에서 GIF 대신 실제 라이브러리를 임베드해 라이브 데모 노출.

## 변경
- 신규 의존성: `@mogiyoon/react-stable-timeline@0.2.2`
- 신규 컴포넌트: [ReactStableTimelineDemo.tsx](src/components/ReactStableTimelineDemo.tsx) — mogiyoon 포트폴리오 프로젝트들의 실제 기간을 sample 데이터로 사용
- [ProjectDetailPage.tsx](src/pages/ProjectDetailPage.tsx) 에서 `projectId === 'react-stable-timeline'` 일 때 GIF 블록을 데모 컴포넌트로 교체

사용자가 직접 pan/zoom 으로 라이브러리의 행 안정성·라벨 측정 동작을 확인할 수 있음.

## Test plan
- [ ] /project/react-stable-timeline 에서 라이브 타임라인이 노출되는지 확인
- [ ] zoom in/out, pan 동작 정상
- [ ] 다른 프로젝트 페이지는 기존 GIF 그대로 노출되는지 확인
- [x] `npm run build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)