### PR TITLE
feat(about): 인트로 스크롤 애니메이션 트리거 기반 개편 및 스크롤 길이 축소

### DIFF
--- a/src/components/AboutMe/BulbContainer.tsx
+++ b/src/components/AboutMe/BulbContainer.tsx
@@ -1,6 +1,7 @@
 // BulbContainer.tsx
-import { useTransform, MotionValue } from 'framer-motion';
+import { MotionValue } from 'framer-motion';
 import { Lightbulb } from './Lightbulb';
+import { useScrollThreshold } from './useScrollThreshold';
 
 interface BulbData {
   id: number;
@@ -14,23 +15,18 @@ interface BulbContainerProps {
   scrollYProgress?: MotionValue<number>;
   bulb: BulbData;
   isSwitchedOn?: boolean;
-  scrollOpacity?: MotionValue<number>;
+  /** 스위치 씬에서 콘텐츠 노출 여부(트리거 latch) */
+  contentShown?: boolean;
 }
 
-// 스크롤 애니메이션을 담당하는 별도의 자식 컴포넌트
+// 스크롤 트리거(latch)를 담당하는 별도의 자식 컴포넌트
 const ScrollAnimatedBulb: React.FC<
   Pick<BulbContainerProps, 'bulb'> & { scrollYProgress: MotionValue<number> }
 > = ({ bulb, scrollYProgress }) => {
-  const bulbOpacity = useTransform(scrollYProgress, [bulb.range![0], bulb.range![1]], [0, 1]);
+  // 임계점(range 시작) 통과 시 일반 속도로 fade-in, 다시 위로 올리면 역재생
+  const shown = useScrollThreshold(scrollYProgress, bulb.range![0]);
 
-  return (
-    <Lightbulb
-      top={bulb.top}
-      left={bulb.left}
-      size={bulb.size}
-      bulbOpacity={bulbOpacity}
-    />
-  );
+  return <Lightbulb top={bulb.top} left={bulb.left} size={bulb.size} bulbShown={shown} />;
 };
 
 // 메인 컨테이너 컴포넌트
@@ -38,22 +34,21 @@ export const BulbContainer: React.FC<BulbContainerProps> = ({
   scrollYProgress,
   bulb,
   isSwitchedOn,
-  scrollOpacity,
+  contentShown,
 }) => {
-  // 조건에 따라 어떤 컴포넌트를 렌더링할지 결정합니다.
-  // Hook 자체를 조건부로 호출하는 것이 아니라, Hook을 사용하는 컴포넌트의 렌더링을 조건부로 결정합니다.
+  // Hook 자체를 조건부로 호출하지 않도록, Hook 을 쓰는 컴포넌트의 렌더링을 조건부로 결정한다.
   if (scrollYProgress && bulb.range) {
     return <ScrollAnimatedBulb scrollYProgress={scrollYProgress} bulb={bulb} />;
   }
 
-  // 스크롤 애니메이션이 없는 경우 (e.g., MainPhrase5to8)
+  // 스위치 씬 (MainPhrase5to8)
   return (
     <Lightbulb
       top={bulb.top}
       left={bulb.left}
       size={bulb.size}
       isSwitchedOn={isSwitchedOn}
-      scrollOpacity={scrollOpacity}
+      bulbShown={contentShown}
     />
   );
 };

--- a/src/components/AboutMe/IntroLine.test.tsx
+++ b/src/components/AboutMe/IntroLine.test.tsx
@@ -71,18 +71,21 @@ describe('IntroLine', () => {
     );
   });
 
-  it('wraps content in a section with the h-[1000vh] sticky scroll container', () => {
+  it('splits the two panels into separate sticky scroll sections', () => {
     const { container } = render(<IntroLine />);
 
-    const section = container.querySelector('section');
-    expect(section).not.toBeNull();
-    expect(section?.className).toContain('h-[1000vh]');
+    const sections = container.querySelectorAll('section');
+    expect(sections).toHaveLength(2);
 
-    const sticky = section?.querySelector('.sticky');
-    expect(sticky).not.toBeNull();
-    expect(sticky?.className).toContain('top-0');
-    expect(sticky?.className).toContain('h-screen');
-    expect(sticky?.className).toContain('overflow-hidden');
+    sections.forEach((section) => {
+      expect(section.className).toContain('h-[200vh]');
+
+      const sticky = section.querySelector('.sticky');
+      expect(sticky).not.toBeNull();
+      expect(sticky?.className).toContain('top-0');
+      expect(sticky?.className).toContain('h-screen');
+      expect(sticky?.className).toContain('overflow-hidden');
+    });
   });
 
   it('forwards the section ref to the targetRef element so useScroll can attach', () => {

--- a/src/components/AboutMe/IntroLine.tsx
+++ b/src/components/AboutMe/IntroLine.tsx
@@ -1,11 +1,7 @@
-import {
-  motion,
-  useScroll,
-  useTransform,
-  type MotionValue,
-} from "framer-motion";
+import { motion, useScroll } from "framer-motion";
 import { useRef } from "react";
 import { useTranslation } from "react-i18next";
+import { useScrollLatch } from "./useScrollLatch";
 
 interface CardData {
   label: string;
@@ -22,83 +18,25 @@ interface IntroPanelData {
   card02: CardData;
 }
 
-interface FadeUpStyle {
-  y: MotionValue<number>;
-  opacity: MotionValue<number>;
-}
-
 interface PanelReveal {
-  eyebrow: FadeUpStyle;
-  title: FadeUpStyle;
-  card01: FadeUpStyle;
-  card02: FadeUpStyle;
+  eyebrow: boolean;
+  title: boolean;
+  card01: boolean;
+  card02: boolean;
 }
 
-function useScrollFadeUp(
-  progress: MotionValue<number>,
-  start: number,
-  duration = 0.05,
-  distance = 24
-): FadeUpStyle {
-  const y = useTransform(progress, [start, start + duration], [distance, 0]);
-  const opacity = useTransform(progress, [start, start + duration], [0, 1]);
-  return { y, opacity };
-}
+const REVEAL_TRANSITION = { duration: 0.5, ease: "easeOut" } as const;
+
+// 섹션 안에서 요소가 순차 등장하는 스크롤 임계값 (각 섹션 0→1 기준)
+const REVEAL_THRESHOLDS = {
+  eyebrow: 0.05,
+  title: 0.12,
+  card01: 0.22,
+  card02: 0.34,
+} as const;
 
 export const IntroLine: React.FC = () => {
   const { t } = useTranslation();
-  const targetRef = useRef<HTMLDivElement | null>(null);
-  const { scrollYProgress } = useScroll({
-    target: targetRef,
-    offset: ["start start", "end start"],
-  });
-
-  const startPanelOpacity = useTransform(
-    scrollYProgress,
-    [0, 0.4, 0.5],
-    [1, 1, 0]
-  );
-  const startPanelY = useTransform(
-    scrollYProgress,
-    [0, 0.1, 0.4, 0.5],
-    [16, 0, 0, -24]
-  );
-  const endPanelOpacity = useTransform(
-    scrollYProgress,
-    [0.45, 0.55, 0.9, 1],
-    [0, 1, 1, 0]
-  );
-  const endPanelY = useTransform(
-    scrollYProgress,
-    [0.45, 0.6, 0.9, 1],
-    [24, 0, 0, -16]
-  );
-
-  // Per-element scroll reveals — startPanel (active 0 → 0.4)
-  const startEyebrow = useScrollFadeUp(scrollYProgress, 0.0, 0.08);
-  const startTitle = useScrollFadeUp(scrollYProgress, 0.04, 0.08);
-  const startCard1 = useScrollFadeUp(scrollYProgress, 0.09, 0.1, 30);
-  const startCard2 = useScrollFadeUp(scrollYProgress, 0.14, 0.1, 30);
-
-  // Per-element scroll reveals — endPanel (active 0.5 → 0.9)
-  const endEyebrow = useScrollFadeUp(scrollYProgress, 0.5, 0.08);
-  const endTitle = useScrollFadeUp(scrollYProgress, 0.54, 0.08);
-  const endCard1 = useScrollFadeUp(scrollYProgress, 0.59, 0.1, 30);
-  const endCard2 = useScrollFadeUp(scrollYProgress, 0.64, 0.1, 30);
-
-  const startReveal: PanelReveal = {
-    eyebrow: startEyebrow,
-    title: startTitle,
-    card01: startCard1,
-    card02: startCard2,
-  };
-
-  const endReveal: PanelReveal = {
-    eyebrow: endEyebrow,
-    title: endTitle,
-    card01: endCard1,
-    card02: endCard2,
-  };
 
   const startPanel: IntroPanelData = {
     eyebrow: t("introStart.eyebrow"),
@@ -136,43 +74,46 @@ export const IntroLine: React.FC = () => {
     },
   };
 
+  // 두 패널을 각각 독립된 sticky 섹션으로 분리한다.
+  // 한 패널이 등장한 뒤 사라지지 않고, 다음 섹션으로 자연 스크롤되며 넘어간다.
   return (
-    <section ref={targetRef} className="relative h-[1000vh] bg-white">
-      <div className="sticky top-0 h-screen w-full overflow-hidden bg-white">
-        <PanelLayer
-          opacity={startPanelOpacity}
-          y={startPanelY}
-          reveal={startReveal}
-          data={startPanel}
-          connector="arrow"
-        />
-        <PanelLayer
-          opacity={endPanelOpacity}
-          y={endPanelY}
-          reveal={endReveal}
-          data={endPanel}
-          connector="plus"
-        />
-      </div>
-    </section>
+    <>
+      <IntroPanelSection data={startPanel} connector="arrow" />
+      <IntroPanelSection data={endPanel} connector="plus" />
+    </>
   );
 };
 
 type ConnectorVariant = "arrow" | "plus";
 
-interface PanelLayerProps {
-  opacity: MotionValue<number>;
-  y: MotionValue<number>;
-  reveal: PanelReveal;
+interface IntroPanelSectionProps {
   data: IntroPanelData;
   connector: ConnectorVariant;
 }
 
-const PanelLayer = ({ opacity, y, reveal, data, connector }: PanelLayerProps) => (
-  <motion.div style={{ opacity, y }} className="absolute inset-0">
-    <IntroPanel {...data} reveal={reveal} connector={connector} />
-  </motion.div>
-);
+const IntroPanelSection = ({ data, connector }: IntroPanelSectionProps) => {
+  const targetRef = useRef<HTMLDivElement | null>(null);
+  const { scrollYProgress } = useScroll({
+    target: targetRef,
+    offset: ["start start", "end start"],
+  });
+
+  // 임계점 통과 시 latch — 한 번 등장하면 섹션이 스크롤로 넘어갈 때까지 유지
+  const reveal: PanelReveal = {
+    eyebrow: useScrollLatch(scrollYProgress, REVEAL_THRESHOLDS.eyebrow),
+    title: useScrollLatch(scrollYProgress, REVEAL_THRESHOLDS.title),
+    card01: useScrollLatch(scrollYProgress, REVEAL_THRESHOLDS.card01),
+    card02: useScrollLatch(scrollYProgress, REVEAL_THRESHOLDS.card02),
+  };
+
+  return (
+    <section ref={targetRef} className="relative h-[200vh] bg-white">
+      <div className="sticky top-0 h-screen w-full overflow-hidden bg-white">
+        <IntroPanel {...data} reveal={reveal} connector={connector} />
+      </div>
+    </section>
+  );
+};
 
 interface IntroPanelProps extends IntroPanelData {
   reveal: PanelReveal;
@@ -193,7 +134,9 @@ const IntroPanel = ({
       {/* Left column */}
       <div className="flex flex-col gap-4 sm:gap-5 lg:gap-6">
         <motion.div
-          style={reveal.eyebrow}
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: reveal.eyebrow ? 1 : 0, y: reveal.eyebrow ? 0 : 24 }}
+          transition={REVEAL_TRANSITION}
           className="flex items-center gap-3"
         >
           <span className="w-2 h-2 rounded-full bg-accent-500" />
@@ -204,7 +147,9 @@ const IntroPanel = ({
         </motion.div>
 
         <motion.h2
-          style={reveal.title}
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: reveal.title ? 1 : 0, y: reveal.title ? 0 : 24 }}
+          transition={REVEAL_TRANSITION}
           className="text-3xl sm:text-4xl md:text-5xl lg:text-5xl font-bold leading-[1.35] tracking-tight"
         >
           <span className="block text-content-strong">{titleLine1}</span>
@@ -214,13 +159,25 @@ const IntroPanel = ({
 
       {/* Right column — desktop only */}
       <div className="hidden lg:flex relative flex-col gap-5 w-full max-h-[80vh] justify-center">
-        <motion.div style={reveal.card01}>
+        <motion.div
+          initial={{ opacity: 0, y: 30 }}
+          animate={{ opacity: reveal.card01 ? 1 : 0, y: reveal.card01 ? 0 : 30 }}
+          transition={REVEAL_TRANSITION}
+        >
           <NumberedCard {...card01} />
         </motion.div>
-        <motion.div style={reveal.card01}>
+        <motion.div
+          initial={{ opacity: 0, y: 30 }}
+          animate={{ opacity: reveal.card01 ? 1 : 0, y: reveal.card01 ? 0 : 30 }}
+          transition={REVEAL_TRANSITION}
+        >
           <Connector variant={connector} />
         </motion.div>
-        <motion.div style={reveal.card02}>
+        <motion.div
+          initial={{ opacity: 0, y: 30 }}
+          animate={{ opacity: reveal.card02 ? 1 : 0, y: reveal.card02 ? 0 : 30 }}
+          transition={REVEAL_TRANSITION}
+        >
           <NumberedCard {...card02} />
         </motion.div>
       </div>

--- a/src/components/AboutMe/Lightbulb.tsx
+++ b/src/components/AboutMe/Lightbulb.tsx
@@ -1,34 +1,27 @@
 // Lightbulb.tsx
-import { motion, MotionValue, useTransform, useMotionValue } from 'framer-motion'; // ✨ useMotionValue import
+import { motion } from 'framer-motion';
 
 interface LightbulbProps {
   top: string;
   left: string;
   size: number;
-  bulbOpacity?: MotionValue<number>;
+  /** 표시 트리거 — 스크롤 임계점 통과 시(또는 콘텐츠 노출 시) true 로 latch */
+  bulbShown?: boolean;
+  /** 스위치 씬(MainPhrase5to8)에서만 사용 */
   isSwitchedOn?: boolean;
-  scrollOpacity?: MotionValue<number>;
 }
 
 export const Lightbulb: React.FC<LightbulbProps> = ({
   top,
   left,
   size,
-  bulbOpacity,
+  bulbShown,
   isSwitchedOn,
-  scrollOpacity,
 }) => {
-  const hasScrollAnimation = bulbOpacity !== undefined;
-
-  // ✨ 수정 1: prop으로 받은 MotionValue가 없을 경우를 대비한 기본 MotionValue를 생성합니다.
-  const defaultOpacity = useMotionValue(0);
-
-  // ✨ 수정 2: `|| 0` 대신 `|| defaultOpacity`를 사용하여 항상 MotionValue 타입이 되도록 보장합니다.
-  const sourceOpacity = scrollOpacity || bulbOpacity || defaultOpacity;
-
-  const combinedOpacity = useTransform(sourceOpacity, (latestOpacity) => {
-    return latestOpacity * (isSwitchedOn ? 1 : 0);
-  });
+  // 스위치 씬: 콘텐츠가 노출되고(bulbShown) 스위치가 켜졌을 때만 보임
+  // 스크롤 씬(isSwitchedOn 미지정): 임계점 통과(bulbShown) 시 보임
+  const visible =
+    isSwitchedOn !== undefined ? bulbShown !== false && isSwitchedOn : !!bulbShown;
 
   const imgVariants = {
     on: {
@@ -42,13 +35,10 @@ export const Lightbulb: React.FC<LightbulbProps> = ({
   return (
     <motion.div
       className="absolute"
-      style={{
-        top,
-        left,
-        width: size,
-        height: size,
-        opacity: hasScrollAnimation ? bulbOpacity : combinedOpacity,
-      }}
+      style={{ top, left, width: size, height: size }}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: visible ? 1 : 0 }}
+      transition={{ duration: 0.5, ease: 'easeInOut' }}
     >
       <motion.div
         className="absolute inset-0 rounded-full"

--- a/src/components/AboutMe/MainPhrase1to4.tsx
+++ b/src/components/AboutMe/MainPhrase1to4.tsx
@@ -1,8 +1,9 @@
 // MainPhrase1to4.tsx
-import { motion, useScroll, useTransform } from 'framer-motion';
+import { motion, useScroll } from 'framer-motion';
 import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { BulbContainer } from './BulbContainer';
+import { useScrollThreshold } from './useScrollThreshold';
 
 // 전구들의 위치, 크기, 애니메이션 타이밍 정보를 담은 데이터
 const bulbData = [
@@ -31,11 +32,12 @@ export const MainPhrase1to4: React.FC = () => {
     offset: ['start start', 'end start'],
   });
 
-  const middleBackgroundOpacity = useTransform(scrollYProgress, [0.5, 0.7], [0, 1]); // 범위를 조금 넓힘
-  const endBackgroundOpacity = useTransform(scrollYProgress, [0.7, 0.8], [0, 1]); // 시작점을 뒤로 미룸
+  // 스크롤 임계점 통과 시 일반 속도로 fade-in, 다시 위로 올리면 역재생
+  const middleShown = useScrollThreshold(scrollYProgress, 0.5);
+  const endShown = useScrollThreshold(scrollYProgress, 0.7);
 
   return (
-    <section ref={targetRef} className="relative h-[1600vh]">
+    <section ref={targetRef} className="relative h-[800vh]">
       <div className="sticky top-0 h-screen w-full overflow-hidden">
         <div className='absolute inset-0 bg-gradient-to-br from-blue-200 to-purple-200 text-content'>
           {/* 시작 콘텐츠 */}
@@ -50,8 +52,10 @@ export const MainPhrase1to4: React.FC = () => {
             style={{
               background: `radial-gradient(ellipse at center bottom, rgba(255,165,0,0.4) 0%, rgba(255,255,0,0.2) 40%, transparent 70%),
                           linear-gradient(to top, #ff6f61 0%, #ffb347 50%, #ffe0b2 100%)`,
-              opacity: middleBackgroundOpacity,
             }}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: middleShown ? 1 : 0 }}
+            transition={{ duration: 0.6, ease: 'easeInOut' }}
           />
 
           <p className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-xl sm:text-2xl lg:text-3xl tracking-widest whitespace-nowrap">
@@ -73,8 +77,10 @@ export const MainPhrase1to4: React.FC = () => {
 
           {/* 끝 콘텐츠 */}
           <motion.div
-            style={{ opacity: endBackgroundOpacity }}
             className='absolute inset-0 z-30 bg-slate-800 text-white'
+            initial={{ opacity: 0 }}
+            animate={{ opacity: endShown ? 1 : 0 }}
+            transition={{ duration: 0.6, ease: 'easeInOut' }}
           />
         </div>
       </div>

--- a/src/components/AboutMe/MainPhrase5to8.tsx
+++ b/src/components/AboutMe/MainPhrase5to8.tsx
@@ -1,9 +1,10 @@
 // MainPhrase5to8.tsx
-import { motion, useScroll, useTransform } from 'framer-motion';
+import { motion, useScroll } from 'framer-motion';
 import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { BulbContainer } from './BulbContainer';
 import { Switch } from './Switch'; // 새로 만든 스위치 컴포넌트 import
+import { useScrollThreshold } from './useScrollThreshold';
 
 // 전구 데이터
 const bulbData = [
@@ -40,11 +41,10 @@ export const MainPhrase5to8: React.FC = () => {
     offset: ['start start', 'end end'],
   });
 
-  // 섹션 중간에서 나타나고, 섹션 끝(90%~100%)에서 사라짐
-  const switchShow = useTransform(scrollYProgress, [0.4, 0.7], [0, 1]);
-  const switchHide = useTransform(sectionFullProgress, [0.85, 0.95], [1, 0]);
-  const switchOpacity = useTransform(() => switchShow.get() * switchHide.get());
-  const contentOpacity = useTransform(scrollYProgress, [0.4, 0.7], [0, 1]);
+  // 스크롤 임계점 기준 양방향 — 콘텐츠 노출 / 스위치 숨김 (위로 올리면 역재생)
+  const contentShown = useScrollThreshold(scrollYProgress, 0.4);
+  const switchHidden = useScrollThreshold(sectionFullProgress, 0.85);
+  const switchVisible = contentShown && !switchHidden;
 
   // 🟡 스위치 클릭 핸들러 수정
   const handleSwitchClick = () => {
@@ -53,7 +53,7 @@ export const MainPhrase5to8: React.FC = () => {
   };
 
   return (
-    <section ref={targetRef} className="relative h-[500vh]">
+    <section ref={targetRef} className="relative h-[250vh]">
       <div className="sticky top-0 h-screen w-full overflow-hidden">
         <div className="absolute inset-0 bg-slate-800 text-white">
 
@@ -63,14 +63,16 @@ export const MainPhrase5to8: React.FC = () => {
                 key={bulb.id}
                 bulb={bulb}
                 isSwitchedOn={isSwitchedOn}
-                scrollOpacity={contentOpacity} 
+                contentShown={contentShown}
               />
             ))}
           </div>
 
           <motion.div
             className={`absolute inset-0 z-20`}
-            style={{ opacity: contentOpacity }}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: contentShown ? 1 : 0 }}
+            transition={{ duration: 0.5, ease: 'easeInOut' }}
           >
             <div className="relative z-20 flex h-full w-full items-center justify-center">
               <p
@@ -102,7 +104,7 @@ export const MainPhrase5to8: React.FC = () => {
 
           <Switch
             onClick={handleSwitchClick}
-            opacity={switchOpacity}
+            visible={switchVisible}
             isSwitchedOn={isSwitchedOn}
           />
         </div>

--- a/src/components/AboutMe/Switch.tsx
+++ b/src/components/AboutMe/Switch.tsx
@@ -1,19 +1,21 @@
 // Switch.tsx
-import { motion, MotionValue, useTransform } from 'framer-motion';
+import { motion } from 'framer-motion';
 import { animation } from '../../design-tokens';
 
 interface SwitchProps {
   onClick: () => void;
-  opacity: MotionValue<number>;
+  /** 표시 트리거 — 스크롤 임계점 통과 시 latch */
+  visible: boolean;
   isSwitchedOn: boolean;
 }
 
-export const Switch: React.FC<SwitchProps> = ({ onClick, opacity, isSwitchedOn }) => {
-  const pointerEvents = useTransform(opacity, (v) => (v > 0.05 ? 'auto' : 'none'));
-
+export const Switch: React.FC<SwitchProps> = ({ onClick, visible, isSwitchedOn }) => {
   return (
     <motion.div
-      style={{ opacity, pointerEvents }}
+      style={{ pointerEvents: visible ? 'auto' : 'none' }}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: visible ? 1 : 0 }}
+      transition={{ duration: 0.4, ease: 'easeInOut' }}
       className="fixed bottom-10 left-1/2 -translate-x-1/2 z-50 flex flex-col items-center gap-2"
     >
       <button

--- a/src/components/AboutMe/useScrollLatch.ts
+++ b/src/components/AboutMe/useScrollLatch.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+import { useMotionValueEvent, type MotionValue } from 'framer-motion';
+
+/**
+ * scrollYProgress 가 threshold 를 한 번이라도 통과하면 true 로 고정(latch)된다.
+ * 스크롤을 다시 위로 올려도 false 로 되돌아가지 않는다 ("한 번만 재생 후 유지").
+ *
+ * 스크롤 위치에 opacity 를 직접 연동(useTransform)하는 대신,
+ * 이 boolean 을 motion 의 animate 대상으로 써서 임계점 도달 시
+ * 일정 시간 동안 일반 속도로 재생되도록 한다.
+ */
+export function useScrollLatch(progress: MotionValue<number>, threshold: number): boolean {
+  const [latched, setLatched] = useState(() => progress.get() >= threshold);
+
+  useMotionValueEvent(progress, 'change', (value) => {
+    if (value >= threshold) setLatched(true);
+  });
+
+  useEffect(() => {
+    if (progress.get() >= threshold) setLatched(true);
+  }, [progress, threshold]);
+
+  return latched;
+}

--- a/src/components/AboutMe/useScrollThreshold.ts
+++ b/src/components/AboutMe/useScrollThreshold.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+import { useMotionValueEvent, type MotionValue } from 'framer-motion';
+
+/**
+ * scrollYProgress 가 threshold 이상이면 true, 미만이면 false (양방향).
+ *
+ * useScrollLatch 와 달리 되돌아간다: 임계점을 지나면 일반 속도로 재생되고,
+ * 다시 위로 올려 임계점을 벗어나면 같은 속도로 역재생된다.
+ * 스크롤 위치에 opacity 를 직접 연동(useTransform)하는 대신 이 boolean 을
+ * motion 의 animate 대상으로 써서 "특정 위치에서 일반 속도로 전환"되게 한다.
+ */
+export function useScrollThreshold(progress: MotionValue<number>, threshold: number): boolean {
+  const [active, setActive] = useState(() => progress.get() >= threshold);
+
+  useMotionValueEvent(progress, 'change', (value) => {
+    setActive(value >= threshold);
+  });
+
+  useEffect(() => {
+    setActive(progress.get() >= threshold);
+  }, [progress, threshold]);
+
+  return active;
+}


### PR DESCRIPTION
## 개요
인트로(About) 섹션의 애니메이션을 **스크롤 위치 직접 연동(useTransform)** 에서 **임계점 기반(시간 재생)** 으로 바꾸고, 섹션 스크롤 길이를 줄였습니다.

## 변경 사항
- **신규 훅**
  - `useScrollLatch` — 임계점 통과 시 등장, 이후 유지(되돌아가지 않음)
  - `useScrollThreshold` — 임계점 기준 양방향(스크롤 올리면 역재생)
- **IntroLine** — 시작/끝 패널을 **각각 독립 sticky 섹션으로 분리**. 패널 크로스페이드·fade-out 제거(애니메이션이 서로 덮어쓰지 않음), 요소별 등장은 latch 로 유지
- **MainPhrase1to4 / 5to8 / 전구** — 임계점 통과 시 일반 속도로 재생, 스크롤 올리면 역재생(reversible)
- **Lightbulb / BulbContainer / Switch** — MotionValue opacity → boolean 트리거 기반으로 단순화
- **스크롤 길이 축소** — 섹션 높이 절감

## 동작 차이
- IntroLine: 위로 올려도 사라지지 않음(등장 유지)
- MainPhrase: 위로 올리면 자연스럽게 역재생

## 검증
- 타입체크(tsc) OK · ESLint OK
- 테스트 200 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)