### PR TITLE
feat(header): 모바일에서 헤더 항상 노출 + useMediaQuery 프리미티브 추출

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 추출 완료된 프리미티브:
 
-- Hooks: `useDisclosure`, `useBodyScrollLock`, `useEscapeKey`, `useClickOutside`, `useCopyToClipboardWithToast`, `useToggleSet`, `useFetchJson`
+- Hooks: `useDisclosure`, `useBodyScrollLock`, `useEscapeKey`, `useClickOutside`, `useCopyToClipboardWithToast`, `useToggleSet`, `useFetchJson`, `useMediaQuery`
 - Components: `Chip`, `ModalShell`, `FlippableCard`, `RotatingChevron`, `BulletList`, `InfoCell`, `ExternalLink`, `TimelineStep` (모두 `src/components/primitives/`)
 - Utils: `placeholders.ts` (`PLACEHOLDER_*` 상수), `imageFallback.ts` (`createImageFallbackHandler`), `formatIndex.ts` (`formatIndex`), `motionPresets.ts` (`collapseVerticalPreset`), `i18nArray.ts` (`fetchI18nArray`)
 - Tokens (design-tokens.ts 추가분): `easings.{projectCard, toast, standard}`, `TOAST_VISIBLE_MS`

--- a/docs/conventions/shared-primitives.md
+++ b/docs/conventions/shared-primitives.md
@@ -30,6 +30,7 @@
 | 모달 / 오버레이가 열린 동안 body 스크롤 잠그기 | `useBodyScrollLock` | `src/hooks/useBodyScrollLock.ts` |
 | Esc 키로 닫기 | `useEscapeKey` | `src/hooks/useEscapeKey.ts` |
 | 드롭다운 / 팝오버 외부 클릭 감지 | `useClickOutside` | `src/hooks/useClickOutside.ts` |
+| CSS media query 매치 여부 추적 (breakpoint 분기 등) | `useMediaQuery` | `src/hooks/useMediaQuery.ts` |
 | 클립보드 복사 + 토스트 자동 노출/해제 | `useCopyToClipboardWithToast` | `src/hooks/useCopyToClipboardWithToast.ts` |
 | prerender 완료 신호용 `render-event` 디스패치 | `usePrerenderReadyEvent` | `src/hooks/usePrerenderReadyEvent.ts` |
 | `<img>` 깨졌을 때 placeholder 로 swap | `createImageFallbackHandler` | `src/utils/imageFallback.ts` |
@@ -358,6 +359,37 @@ useClickOutside(ref, close, isOpen);
 
 - `click` 이벤트로 직접 구현 → focus 트랩 / 다중 dropdown 시 race 가 발생한다. `mousedown` 이 의도된 선택
 - `active` 인자를 빼먹어서 항상 리스너가 붙음 → 닫혀 있을 때 불필요한 리스너 비용
+
+---
+
+### `useMediaQuery` (`src/hooks/useMediaQuery.ts`)
+
+**언제 쓰나**
+
+- Tailwind breakpoint 기준으로 JS 로직을 분기해야 할 때 (모바일/데스크톱에서 다른 동작·마운트 전략)
+- `window.matchMedia` + `change` 리스너 조합을 인라인으로 작성하려고 할 때
+- App(헤더 표시 로직), ProjectsSidebar(AI DevKit 마운트 전략) 가 사용 중
+
+**기본 사용법**
+
+```tsx
+import { useMediaQuery } from '@/hooks/useMediaQuery';
+
+const isDesktop = useMediaQuery('(min-width: 1024px)'); // Tailwind lg
+const isMobile = !useMediaQuery('(min-width: 768px)');  // Tailwind md 미만
+```
+
+**제공되는 동작**
+
+- 초기값은 마운트 시점의 `matchMedia(query).matches` 로 동기 평가 (첫 렌더부터 정확)
+- viewport 가 breakpoint 를 넘나들면 `change` 이벤트로 자동 재평가
+- `window` / `matchMedia` 가 없는 환경(SSR, jsdom 테스트)에서는 `false` 반환
+
+**자주 하는 실수**
+
+- `window.matchMedia('...')` + `addEventListener('change', ...)` 를 컴포넌트 안에 인라인 작성 → 이 훅을 사용
+- `window.innerWidth >= 768` 스냅샷 비교 → resize 에 반응하지 않는다. media query 로 표현할 수 있으면 이 훅을 사용
+- Tailwind breakpoint 와 다른 임의 픽셀값 사용 → `sm(640)` / `md(768)` / `lg(1024)` 등 Tailwind 기준값과 일치시킬 것
 
 ---
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import ContactModal from "./components/ContactModal";
 import PageHeader from "./components/PageHeader";
 import { AnimatePresence } from 'framer-motion';
 import { useDisclosure } from "./hooks/useDisclosure";
+import { useMediaQuery } from "./hooks/useMediaQuery";
 import { easings } from "./design-tokens";
 
 const getInitialTab = () => {
@@ -35,6 +36,8 @@ const AppContent: React.FC = () => {
   const [isSmoothReveal, setIsSmoothReveal] = useState(false);
   const lastScrollY = useRef(0);
   const headerRevealed = useRef(window.location.pathname !== '/');
+  // 모바일(Tailwind md 미만)에서는 숨김/호버 로직 없이 헤더 항상 노출
+  const isMobile = !useMediaQuery('(min-width: 768px)');
 
   const revealHeader = useCallback(() => {
     headerRevealed.current = true;
@@ -77,7 +80,7 @@ const AppContent: React.FC = () => {
   }, [activeTab, location.pathname]);
 
   useEffect(() => {
-    if (headerRevealed.current) {
+    if (isMobile || headerRevealed.current) {
       return;
     }
     const timer = setTimeout(() => {
@@ -86,9 +89,12 @@ const AppContent: React.FC = () => {
       }
     }, HEADER_REVEAL_DELAY_MS);
     return () => clearTimeout(timer);
-  }, [isMainPageTop, revealHeader]);
+  }, [isMobile, isMainPageTop, revealHeader]);
 
   useEffect(() => {
+    if (isMobile) {
+      return;
+    }
     const SCROLL_THRESHOLD = 20;
 
     const handleScroll = () => {
@@ -114,12 +120,12 @@ const AppContent: React.FC = () => {
     };
     window.addEventListener("scroll", handleScroll, { passive: true });
     return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
+  }, [isMobile]);
 
   return (
     <main>
       {/* 헤더가 숨겨져 있을 때 상단 가장자리 호버로 다시 나타나게 하는 감지 영역 */}
-      {headerTranslate < 0 && (
+      {!isMobile && headerTranslate < 0 && (
         <div
           data-print-hidden="true"
           style={{ height: HEADER_HEIGHT }}
@@ -129,10 +135,10 @@ const AppContent: React.FC = () => {
       )}
       <div
         data-print-hidden="true"
-        onMouseEnter={headerTranslate < 0 ? revealHeader : undefined}
-        onMouseLeave={handleHeaderMouseLeave}
+        onMouseEnter={!isMobile && headerTranslate < 0 ? revealHeader : undefined}
+        onMouseLeave={isMobile ? undefined : handleHeaderMouseLeave}
         style={{
-          transform: `translateY(${headerTranslate}px)`,
+          transform: `translateY(${isMobile ? 0 : headerTranslate}px)`,
           transition: isSmoothReveal
             ? `transform 0.4s cubic-bezier(${easings.standard.join(",")})`
             : "transform 0.1s linear",

--- a/src/components/ProjectsSidebar.tsx
+++ b/src/components/ProjectsSidebar.tsx
@@ -1,28 +1,13 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { motion } from 'framer-motion';
 
 import { PROJECT_CARD_EASE } from '../hooks/useProjectGridEntrance';
 import type { ProjectDevKitCardData, ProjectDevKitId } from '../hooks/useProjectDevKitItems';
+import { useMediaQuery } from '../hooks/useMediaQuery';
 import type { ProjectSummary } from '../types';
 import AiDevKitCard from './AiDevKitCard';
 import ProjectFlipPreviewCard from './ProjectFlipPreviewCard';
 import StickySectionSidebar from './StickySectionSidebar';
-
-// Tailwind `lg` (1024px) 기준. 데스크톱은 카드 entrance 후 AI DevKit 이 blur+scale 로
-// 등장하지만, 모바일은 처음부터 마운트해 애니메이션 없이 노출 (피드백 반영).
-const useIsDesktop = () => {
-    const [isDesktop, setIsDesktop] = useState(() =>
-        typeof window !== 'undefined' && window.matchMedia('(min-width: 1024px)').matches
-    );
-    useEffect(() => {
-        if (typeof window === 'undefined') return;
-        const mq = window.matchMedia('(min-width: 1024px)');
-        const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
-        mq.addEventListener('change', handler);
-        return () => mq.removeEventListener('change', handler);
-    }, []);
-    return isDesktop;
-};
 
 interface ProjectsSidebarProps {
     title: string;
@@ -45,7 +30,9 @@ const ProjectsSidebar: React.FC<ProjectsSidebarProps> = ({
     devKitItems,
     onSelectDevKit,
 }) => {
-    const isDesktop = useIsDesktop();
+    // Tailwind `lg` (1024px) 기준. 데스크톱은 카드 entrance 후 AI DevKit 이 blur+scale 로
+    // 등장하지만, 모바일은 처음부터 마운트해 애니메이션 없이 노출 (피드백 반영).
+    const isDesktop = useMediaQuery('(min-width: 1024px)');
 
     const devKitCardBlock = (
         <div className="rounded-card bg-surface p-4 shadow-lg sm:p-5">

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * CSS media query 매치 여부를 추적하는 훅.
+ * viewport 변경 시 자동으로 재평가된다. window / matchMedia 가 없는 환경(테스트 등)에서는 false.
+ *
+ * @example
+ * const isDesktop = useMediaQuery('(min-width: 1024px)');
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia(query).matches
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const mq = window.matchMedia(query);
+    setMatches(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, [query]);
+
+  return matches;
+}


### PR DESCRIPTION
## Summary
- 모바일 사이즈(Tailwind `md` 미만, 768px)에서는 헤더 숨김/호버/2.5초 타이머 로직을 모두 비활성화하고 헤더를 항상 노출
- `window.matchMedia` + `change` 리스너 패턴을 `useMediaQuery` 훅으로 추출 (`src/hooks/useMediaQuery.ts`)
  - ProjectsSidebar 의 인라인 `useIsDesktop` 과 App 헤더 로직, 2곳 사용으로 프리미티브 추출 조건 충족
- ProjectsSidebar 의 인라인 훅을 `useMediaQuery('(min-width: 1024px)')` 로 교체 (동작 동일)
- CLAUDE.md / docs/conventions/shared-primitives.md 에 `useMediaQuery` 등록

## Behavior
- 데스크톱(≥768px): 기존 동작 유지 — 메인 최상단에서 2.5초 후 자동 표시 / 호버 표시 / 이탈 시 숨김 / 스크롤 연동
- 모바일(<768px): 헤더 항상 표시, 창 크기 변경 시 자동으로 모드 전환

## Test plan
- `npx tsc --noEmit` 통과
- `eslint` (App.tsx, useMediaQuery.ts, ProjectsSidebar.tsx) 통과
- `npm test` 32개 파일 200개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)