### PR TITLE
feat(resume): 이력서 페이지 모바일 대응 + 플로팅 편집 버튼

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 추출 완료된 프리미티브:
 
-- Hooks: `useDisclosure`, `useBodyScrollLock`, `useEscapeKey`, `useClickOutside`, `useCopyToClipboardWithToast`, `useToggleSet`, `useFetchJson`
+- Hooks: `useDisclosure`, `useBodyScrollLock`, `useEscapeKey`, `useClickOutside`, `useCopyToClipboardWithToast`, `useToggleSet`, `useFetchJson`, `useMediaQuery`
 - Components: `Chip`, `ModalShell`, `FlippableCard`, `RotatingChevron`, `BulletList`, `InfoCell`, `ExternalLink`, `TimelineStep` (모두 `src/components/primitives/`)
 - Utils: `placeholders.ts` (`PLACEHOLDER_*` 상수), `imageFallback.ts` (`createImageFallbackHandler`), `formatIndex.ts` (`formatIndex`), `motionPresets.ts` (`collapseVerticalPreset`), `i18nArray.ts` (`fetchI18nArray`)
 - Tokens (design-tokens.ts 추가분): `easings.{projectCard, toast, standard}`, `TOAST_VISIBLE_MS`

--- a/docs/conventions/shared-primitives.md
+++ b/docs/conventions/shared-primitives.md
@@ -30,6 +30,7 @@
 | 모달 / 오버레이가 열린 동안 body 스크롤 잠그기 | `useBodyScrollLock` | `src/hooks/useBodyScrollLock.ts` |
 | Esc 키로 닫기 | `useEscapeKey` | `src/hooks/useEscapeKey.ts` |
 | 드롭다운 / 팝오버 외부 클릭 감지 | `useClickOutside` | `src/hooks/useClickOutside.ts` |
+| CSS media query 매치 여부 추적 (breakpoint 분기 등) | `useMediaQuery` | `src/hooks/useMediaQuery.ts` |
 | 클립보드 복사 + 토스트 자동 노출/해제 | `useCopyToClipboardWithToast` | `src/hooks/useCopyToClipboardWithToast.ts` |
 | prerender 완료 신호용 `render-event` 디스패치 | `usePrerenderReadyEvent` | `src/hooks/usePrerenderReadyEvent.ts` |
 | `<img>` 깨졌을 때 placeholder 로 swap | `createImageFallbackHandler` | `src/utils/imageFallback.ts` |
@@ -358,6 +359,37 @@ useClickOutside(ref, close, isOpen);
 
 - `click` 이벤트로 직접 구현 → focus 트랩 / 다중 dropdown 시 race 가 발생한다. `mousedown` 이 의도된 선택
 - `active` 인자를 빼먹어서 항상 리스너가 붙음 → 닫혀 있을 때 불필요한 리스너 비용
+
+---
+
+### `useMediaQuery` (`src/hooks/useMediaQuery.ts`)
+
+**언제 쓰나**
+
+- Tailwind breakpoint 기준으로 JS 로직을 분기해야 할 때 (모바일/데스크톱에서 다른 동작·마운트 전략)
+- `window.matchMedia` + `change` 리스너 조합을 인라인으로 작성하려고 할 때
+- App(헤더 표시 로직), ProjectsSidebar(AI DevKit 마운트 전략) 가 사용 중
+
+**기본 사용법**
+
+```tsx
+import { useMediaQuery } from '@/hooks/useMediaQuery';
+
+const isDesktop = useMediaQuery('(min-width: 1024px)'); // Tailwind lg
+const isMobile = !useMediaQuery('(min-width: 768px)');  // Tailwind md 미만
+```
+
+**제공되는 동작**
+
+- 초기값은 마운트 시점의 `matchMedia(query).matches` 로 동기 평가 (첫 렌더부터 정확)
+- viewport 가 breakpoint 를 넘나들면 `change` 이벤트로 자동 재평가
+- `window` / `matchMedia` 가 없는 환경(SSR, jsdom 테스트)에서는 `false` 반환
+
+**자주 하는 실수**
+
+- `window.matchMedia('...')` + `addEventListener('change', ...)` 를 컴포넌트 안에 인라인 작성 → 이 훅을 사용
+- `window.innerWidth >= 768` 스냅샷 비교 → resize 에 반응하지 않는다. media query 로 표현할 수 있으면 이 훅을 사용
+- Tailwind breakpoint 와 다른 임의 픽셀값 사용 → `sm(640)` / `md(768)` / `lg(1024)` 등 Tailwind 기준값과 일치시킬 것
 
 ---
 

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -145,6 +145,8 @@
     "savePdf": "Save as PDF",
     "resetDraft": "Reset Copy",
     "pinSidebar": "Pin sidebar",
+    "editDraft": "Edit resume",
+    "closeEditor": "Close editor panel",
     "helper": "Select the work you want to include and edit the wording. The HTML resume preview updates on the right in real time.",
     "builder": {
       "basics": "Basics",

--- a/public/locales/ko/common.json
+++ b/public/locales/ko/common.json
@@ -145,6 +145,8 @@
     "savePdf": "PDF로 저장",
     "resetDraft": "문구 초기화",
     "pinSidebar": "사이드바 고정",
+    "editDraft": "이력서 편집",
+    "closeEditor": "편집 패널 닫기",
     "helper": "포함할 작업을 선택하고 문구를 수정하면 오른쪽 HTML 이력서에 바로 반영됩니다.",
     "builder": {
       "basics": "기본 정보",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import ContactModal from "./components/ContactModal";
 import PageHeader from "./components/PageHeader";
 import { AnimatePresence } from 'framer-motion';
 import { useDisclosure } from "./hooks/useDisclosure";
+import { useMediaQuery } from "./hooks/useMediaQuery";
 import { easings } from "./design-tokens";
 
 const getInitialTab = () => {
@@ -35,6 +36,8 @@ const AppContent: React.FC = () => {
   const [isSmoothReveal, setIsSmoothReveal] = useState(false);
   const lastScrollY = useRef(0);
   const headerRevealed = useRef(window.location.pathname !== '/');
+  // 모바일(Tailwind md 미만)에서는 숨김/호버 로직 없이 헤더 항상 노출
+  const isMobile = !useMediaQuery('(min-width: 768px)');
 
   const revealHeader = useCallback(() => {
     headerRevealed.current = true;
@@ -77,7 +80,7 @@ const AppContent: React.FC = () => {
   }, [activeTab, location.pathname]);
 
   useEffect(() => {
-    if (headerRevealed.current) {
+    if (isMobile || headerRevealed.current) {
       return;
     }
     const timer = setTimeout(() => {
@@ -86,9 +89,12 @@ const AppContent: React.FC = () => {
       }
     }, HEADER_REVEAL_DELAY_MS);
     return () => clearTimeout(timer);
-  }, [isMainPageTop, revealHeader]);
+  }, [isMobile, isMainPageTop, revealHeader]);
 
   useEffect(() => {
+    if (isMobile) {
+      return;
+    }
     const SCROLL_THRESHOLD = 20;
 
     const handleScroll = () => {
@@ -114,12 +120,12 @@ const AppContent: React.FC = () => {
     };
     window.addEventListener("scroll", handleScroll, { passive: true });
     return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
+  }, [isMobile]);
 
   return (
     <main>
       {/* 헤더가 숨겨져 있을 때 상단 가장자리 호버로 다시 나타나게 하는 감지 영역 */}
-      {headerTranslate < 0 && (
+      {!isMobile && headerTranslate < 0 && (
         <div
           data-print-hidden="true"
           style={{ height: HEADER_HEIGHT }}
@@ -129,10 +135,10 @@ const AppContent: React.FC = () => {
       )}
       <div
         data-print-hidden="true"
-        onMouseEnter={headerTranslate < 0 ? revealHeader : undefined}
-        onMouseLeave={handleHeaderMouseLeave}
+        onMouseEnter={!isMobile && headerTranslate < 0 ? revealHeader : undefined}
+        onMouseLeave={isMobile ? undefined : handleHeaderMouseLeave}
         style={{
-          transform: `translateY(${headerTranslate}px)`,
+          transform: `translateY(${isMobile ? 0 : headerTranslate}px)`,
           transition: isSmoothReveal
             ? `transform 0.4s cubic-bezier(${easings.standard.join(",")})`
             : "transform 0.1s linear",

--- a/src/components/ProjectsSidebar.tsx
+++ b/src/components/ProjectsSidebar.tsx
@@ -1,28 +1,13 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { motion } from 'framer-motion';
 
 import { PROJECT_CARD_EASE } from '../hooks/useProjectGridEntrance';
 import type { ProjectDevKitCardData, ProjectDevKitId } from '../hooks/useProjectDevKitItems';
+import { useMediaQuery } from '../hooks/useMediaQuery';
 import type { ProjectSummary } from '../types';
 import AiDevKitCard from './AiDevKitCard';
 import ProjectFlipPreviewCard from './ProjectFlipPreviewCard';
 import StickySectionSidebar from './StickySectionSidebar';
-
-// Tailwind `lg` (1024px) 기준. 데스크톱은 카드 entrance 후 AI DevKit 이 blur+scale 로
-// 등장하지만, 모바일은 처음부터 마운트해 애니메이션 없이 노출 (피드백 반영).
-const useIsDesktop = () => {
-    const [isDesktop, setIsDesktop] = useState(() =>
-        typeof window !== 'undefined' && window.matchMedia('(min-width: 1024px)').matches
-    );
-    useEffect(() => {
-        if (typeof window === 'undefined') return;
-        const mq = window.matchMedia('(min-width: 1024px)');
-        const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
-        mq.addEventListener('change', handler);
-        return () => mq.removeEventListener('change', handler);
-    }, []);
-    return isDesktop;
-};
 
 interface ProjectsSidebarProps {
     title: string;
@@ -45,7 +30,9 @@ const ProjectsSidebar: React.FC<ProjectsSidebarProps> = ({
     devKitItems,
     onSelectDevKit,
 }) => {
-    const isDesktop = useIsDesktop();
+    // Tailwind `lg` (1024px) 기준. 데스크톱은 카드 entrance 후 AI DevKit 이 blur+scale 로
+    // 등장하지만, 모바일은 처음부터 마운트해 애니메이션 없이 노출 (피드백 반영).
+    const isDesktop = useMediaQuery('(min-width: 1024px)');
 
     const devKitCardBlock = (
         <div className="rounded-card bg-surface p-4 shadow-lg sm:p-5">

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * CSS media query 매치 여부를 추적하는 훅.
+ * viewport 변경 시 자동으로 재평가된다. window / matchMedia 가 없는 환경(테스트 등)에서는 false.
+ *
+ * @example
+ * const isDesktop = useMediaQuery('(min-width: 1024px)');
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia(query).matches
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const mq = window.matchMedia(query);
+    setMatches(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, [query]);
+
+  return matches;
+}

--- a/src/pages/ResumePreviewPage/index.tsx
+++ b/src/pages/ResumePreviewPage/index.tsx
@@ -28,7 +28,10 @@ import { useSidebarPin } from "./useSidebarPin";
 import { useResumeDraftUpdaters } from "./useResumeDraftUpdaters";
 import { useResumeSelectors } from "./useResumeSelectors";
 import { useToggleSet } from "../../hooks/useToggleSet";
+import { useDisclosure } from "../../hooks/useDisclosure";
+import { useMediaQuery } from "../../hooks/useMediaQuery";
 import ExternalLink from "../../components/primitives/ExternalLink";
+import ModalShell from "../../components/primitives/ModalShell";
 import { usePrerenderReadyEvent } from "../../hooks/usePrerenderReadyEvent";
 
 const ResumePreviewPage: React.FC = () => {
@@ -47,6 +50,14 @@ const ResumePreviewPage: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState("");
   const { asideRef, sidebarColumnRef, isSidebarPinned, pinnedTop, togglePin } = useSidebarPin();
+  // 사이드바를 옆에 배치할 수 있는 폭(Tailwind xl 이상)에서는 사이드바로,
+  // 그 미만(모바일·태블릿)에서는 플로팅 버튼 + 모달로 편집 패널을 제공
+  const canShowSidebar = useMediaQuery("(min-width: 1280px)");
+  const {
+    isOpen: isEditorModalOpen,
+    open: openEditorModal,
+    close: closeEditorModal,
+  } = useDisclosure(false);
 
   useEffect(() => {
     let isMounted = true;
@@ -135,8 +146,8 @@ const ResumePreviewPage: React.FC = () => {
           <div className="h-10 w-56 rounded-2xl bg-slate-200 animate-pulse mb-6" />
           <div className="grid gap-6 xl:grid-cols-[24rem_1fr]">
             <div className="h-[70vh] rounded-paper-edge-lg bg-slate-200 animate-pulse" />
-            <div className="flex justify-center">
-              <div className="h-[297mm] w-[210mm] max-w-full rounded-paper-edge-lg bg-slate-200 animate-pulse" />
+            <div className="flex min-w-0 justify-center">
+              <div className="h-[297mm] w-full max-w-[210mm] rounded-paper-edge-lg bg-slate-200 animate-pulse" />
             </div>
           </div>
         </div>
@@ -226,66 +237,10 @@ const ResumePreviewPage: React.FC = () => {
       })
       .filter(Boolean);
 
-  return (
+  // 편집 섹션 묶음 — 데스크톱에서는 사이드바(aside)에, 모바일에서는 플로팅 버튼으로 여는
+  // 모달(ModalShell)에 동일하게 렌더링한다.
+  const editorSections = (
     <>
-    {resumeSeo}
-    <section className="min-h-screen bg-[#dfe5ec] print:bg-white">
-      <div className="mx-auto max-w-7xl px-4 pt-28 pb-10 print:px-0 print:pt-0">
-        <div data-print-hidden="true" className="mb-5 flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <h1 className="text-3xl font-bold text-slate-950">{t("resume.heading")}</h1>
-            <p className="mt-1.5 text-sm text-slate-600">{t("resume.helper")}</p>
-          </div>
-          <div className="flex flex-wrap items-center gap-3">
-            <Link
-              to="/"
-              state={{ activeTab: "profile" }}
-              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-800 shadow-sm"
-            >
-              {t("resume.backToProfile")}
-            </Link>
-            <button
-              type="button"
-              onClick={resetDraft}
-              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-800 shadow-sm"
-            >
-              {t("resume.resetDraft")}
-            </button>
-            <button
-              type="button"
-              onClick={() => window.print()}
-              className="inline-flex items-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm"
-            >
-              {t("resume.savePdf")}
-            </button>
-          </div>
-        </div>
-
-        <div className="grid gap-4 xl:grid-cols-[23rem_1fr] print:block">
-          <div ref={sidebarColumnRef} className="xl:relative">
-            <aside
-              ref={asideRef}
-              data-print-hidden="true"
-              className={`space-y-4 ${
-                isSidebarPinned
-                  ? "xl:absolute xl:left-0 xl:w-full"
-                  : "xl:sticky xl:top-24"
-              }`}
-              style={
-                isSidebarPinned && pinnedTop !== null
-                  ? { top: pinnedTop }
-                  : undefined
-              }
-            >
-            <label className="hidden xl:flex cursor-pointer items-center gap-2 rounded-full border border-slate-300 bg-white px-3.5 py-2 text-sm font-medium text-slate-700 shadow-sm">
-              <input
-                type="checkbox"
-                checked={isSidebarPinned}
-                onChange={(e) => togglePin(e.target.checked)}
-                className="h-4 w-4 rounded border-slate-300 accent-slate-900"
-              />
-              {t("resume.pinSidebar")}
-            </label>
             <CollapsibleEditorSection
               title={t("resume.builder.basics")}
               isOpen={openPanel === "basics"}
@@ -618,11 +573,77 @@ const ResumePreviewPage: React.FC = () => {
                 )}
               </div>
             </CollapsibleEditorSection>
-            </aside>
-          </div>
+    </>
+  );
 
-          <div className="flex justify-center print:block">
-            <article className="resume-preview-page w-[210mm] max-w-full min-h-[297mm] rounded-paper-edge-lg bg-white px-6 py-5 shadow-resume-paper print:rounded-none print:shadow-none">
+  return (
+    <>
+    {resumeSeo}
+    <section className="min-h-screen bg-[#dfe5ec] print:bg-white">
+      <div className="mx-auto max-w-7xl px-4 pt-28 pb-10 print:px-0 print:pt-0">
+        <div data-print-hidden="true" className="mb-5 flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h1 className="text-3xl font-bold text-slate-950">{t("resume.heading")}</h1>
+            <p className="mt-1.5 text-sm text-slate-600">{t("resume.helper")}</p>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <Link
+              to="/"
+              state={{ activeTab: "profile" }}
+              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-800 shadow-sm"
+            >
+              {t("resume.backToProfile")}
+            </Link>
+            <button
+              type="button"
+              onClick={resetDraft}
+              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-800 shadow-sm"
+            >
+              {t("resume.resetDraft")}
+            </button>
+            <button
+              type="button"
+              onClick={() => window.print()}
+              className="inline-flex items-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm"
+            >
+              {t("resume.savePdf")}
+            </button>
+          </div>
+        </div>
+
+        <div className="grid gap-4 xl:grid-cols-[23rem_1fr] print:block">
+          {canShowSidebar && (
+            <div ref={sidebarColumnRef} className="min-w-0 xl:relative">
+              <aside
+                ref={asideRef}
+                data-print-hidden="true"
+                className={`space-y-4 ${
+                  isSidebarPinned
+                    ? "xl:absolute xl:left-0 xl:w-full"
+                    : "xl:sticky xl:top-24"
+                }`}
+                style={
+                  isSidebarPinned && pinnedTop !== null
+                    ? { top: pinnedTop }
+                    : undefined
+                }
+              >
+                <label className="hidden xl:flex cursor-pointer items-center gap-2 rounded-full border border-slate-300 bg-white px-3.5 py-2 text-sm font-medium text-slate-700 shadow-sm">
+                  <input
+                    type="checkbox"
+                    checked={isSidebarPinned}
+                    onChange={(e) => togglePin(e.target.checked)}
+                    className="h-4 w-4 rounded border-slate-300 accent-slate-900"
+                  />
+                  {t("resume.pinSidebar")}
+                </label>
+                {editorSections}
+              </aside>
+            </div>
+          )}
+
+          <div className="flex min-w-0 justify-center print:block">
+            <article className="resume-preview-page w-full max-w-[210mm] min-h-[297mm] rounded-paper-edge-lg bg-white px-6 py-5 shadow-resume-paper print:w-[210mm] print:rounded-none print:shadow-none">
               <header className="border-b border-slate-200 pb-4">
                 <div className="flex flex-wrap items-start justify-between gap-2.5">
                   <div>
@@ -644,7 +665,7 @@ const ResumePreviewPage: React.FC = () => {
                   </div>
                 </div>
 
-                <div className="mt-3.5 grid grid-cols-2 gap-x-4 gap-y-1.5 text-[13px] text-slate-700">
+                <div className="mt-3.5 grid grid-cols-1 gap-x-4 gap-y-1.5 text-[13px] text-slate-700 sm:grid-cols-2 print:grid-cols-2">
                   {linkOrder.map((key) =>
                     draft.profile.links[key] ? (
                       <div
@@ -881,6 +902,57 @@ const ResumePreviewPage: React.FC = () => {
           </div>
         </div>
       </div>
+
+      {!canShowSidebar && (
+        <button
+          type="button"
+          data-print-hidden="true"
+          onClick={openEditorModal}
+          className="fixed bottom-5 right-5 z-40 inline-flex items-center gap-2 rounded-full bg-slate-900 px-5 py-3.5 text-sm font-semibold text-white shadow-xl"
+        >
+          <svg
+            className="h-4 w-4"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
+          </svg>
+          {t("resume.editDraft")}
+        </button>
+      )}
+
+      <ModalShell
+        isOpen={!canShowSidebar && isEditorModalOpen}
+        onClose={closeEditorModal}
+        className="fixed inset-x-3 bottom-3 top-24 mx-auto max-w-xl flex flex-col overflow-hidden"
+      >
+        <div className="flex shrink-0 items-center justify-between border-b border-slate-200 px-3.5 py-3">
+          <h2 className="text-lg font-bold text-slate-950">{t("resume.editDraft")}</h2>
+          <button
+            type="button"
+            onClick={closeEditorModal}
+            aria-label={t("resume.closeEditor")}
+            className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-500"
+          >
+            <svg
+              className="h-4 w-4"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M18 6 6 18M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        <div className="flex-1 space-y-4 overflow-y-auto p-3.5">{editorSections}</div>
+      </ModalShell>
     </section>
     </>
   );


### PR DESCRIPTION
## Summary
- 모바일에서 이력서 페이지가 화면 밖으로 나가던 가로 오버플로우 수정
  - A4 고정 폭(`w-[210mm]`)이 모바일 단일 컬럼 그리드 트랙을 794px로 밀어내던 문제 → `w-full max-w-[210mm]` + 그리드 컬럼 `min-w-0`, 인쇄는 `print:w-[210mm]`로 A4 유지
- 편집 패널을 "사이드바 or 플로팅 버튼" 방식으로 재구성
  - 사이드바를 옆에 배치할 수 있는 폭(`xl` 이상): 기존 사이드바 유지
  - 그 미만(모바일·태블릿): 우하단 "이력서 편집" 플로팅 버튼 → `ModalShell` 모달로 편집 (편집 섹션 JSX는 `editorSections` 한 벌을 양쪽에서 공유)
  - 모달 헤더(제목 + 닫기)는 스크롤 영역 밖 상단 고정, 태블릿에서는 `max-w-xl` 중앙 정렬
- 미리보기 상단 링크 그리드 모바일 1열 전환 (`sm` 이상/인쇄는 2열 유지)
- i18n 키 추가: `resume.editDraft`, `resume.closeEditor` (ko/en)

## Dependencies
⚠️ **#108 위에 스택된 PR** — `useMediaQuery` 훅(#108에서 추가)에 의존합니다. #108을 먼저 머지하면 이 PR의 diff가 이번 커밋(c864461)만 남습니다.

## Test plan
- Puppeteer 검증: 390px 가로 오버플로우 요소 280개 → 0개, FAB/모달 열기·섹션 토글·헤더 고정 스크린샷 확인
- 1024px(태블릿): FAB + 중앙 모달 / 1440px(데스크톱): 사이드바 + FAB 없음 확인
- print 미디어에서 article 폭 794px(A4) 유지, PDF 렌더링 확인
- `npx tsc --noEmit` / `eslint` / `npm test` 32개 파일 200개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)