### PR TITLE
feat(projects): add tech stack filter card and curate techStack by hiring demand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,15 @@
 ## 3. 프로젝트 목록에 등록
 - `public/data/projects-list.json` — 배열에 항목 추가 (id, title, subtitle, projectType, screenshots, techStack)
 
+### techStack 등재 기준 (2026.08 구직 사이트 수요 조사 기반)
+
+`projects-list.json`의 techStack은 프로젝트 카드와 기술 스택 필터에 노출되므로, **한국 구직 사이트(사람인·잡코리아·원티드·점핏) 채용공고에서 자격요건/우대사항 키워드로 실제 검색되는 스택만** 등재한다. 상세 페이지(`public/data/projects/{id}.json`의 overview.techStack)에는 전체 스택을 기재해도 된다.
+
+- 등재 O (채용 키워드로 다수 등장 확인됨): React, Next.js, TypeScript, JavaScript, Redux, React Native, Flutter, FastAPI, Nest.js, PostgreSQL, AWS, Unity, Firebase, Rust, Provider
+- 등재 O — 예외 유지 (채용 키워드는 아니지만 프로젝트 정체성·차별성을 드러내는 도메인/도구 키워드): claude CLI, MCP, npm Package, Chrome Extension, AR/VR, ffmpeg, Google Vision API
+- 등재 X (채용 키워드로 거의/전혀 쓰이지 않음 — 상위 개념으로 대체됨): SQLAlchemy, SQLite, yfinance, APScheduler, Chart.js, Tauri, @xyflow/react, Canvas2D, tsup, Manifest V3, Material Design
+- 목록에 없는 새 스택은 "채용공고 자격요건에 해당 키워드가 명시된 공고가 다수 존재하는가"를 기준으로 판단한다. 특정 라이브러리/도구 명칭은 대체로 언어·프레임워크(예: Python, React) 수준으로만 공고에 기재되므로 등재하지 않되, 프로젝트의 정체성을 대표하는 키워드는 예외로 등재할 수 있다.
+
 ## 4. 프로젝트 카드 번역 등록
 - `public/locales/ko/projects.json` — 한국어 title, subtitle, overview.projectType 추가
 - `public/locales/en/projects.json` — 영어 title, subtitle, overview.projectType 추가

--- a/public/data/projects-list.json
+++ b/public/data/projects-list.json
@@ -6,7 +6,7 @@
     "projectType": "stock-compass.overview.projectType",
     "period": "2026.05",
     "screenshots": [{ "src": "/images/stockCompass/Icon.png", "alt": "Stock Compass Thumbnail" }],
-    "techStack": ["FastAPI", "SQLAlchemy", "SQLite", "yfinance", "claude CLI", "APScheduler", "Chart.js"],
+    "techStack": ["FastAPI", "claude CLI"],
     "claudeInfo": {
       "method": "orchestrator",
       "summary": "stock-compass.claudeInfo.summary"
@@ -19,7 +19,7 @@
     "projectType": "storytect.overview.projectType",
     "period": "2026.05",
     "screenshots": [{ "src": "/images/storytect/Icon.svg", "alt": "Storytect Thumbnail" }],
-    "techStack": ["Tauri", "Rust", "Next.js", "React", "TypeScript", "@xyflow/react", "MCP"],
+    "techStack": ["Rust", "Next.js", "React", "TypeScript", "MCP"],
     "claudeInfo": {
       "method": "orchestrator",
       "summary": "storytect.claudeInfo.summary"
@@ -32,7 +32,7 @@
     "projectType": "react-stable-timeline.overview.projectType",
     "period": "2026.05",
     "screenshots": [{ "src": "/images/reactStableTimeline/Icon.svg", "alt": "react-stable-timeline Thumbnail" }],
-    "techStack": ["React", "TypeScript", "Canvas2D", "tsup", "npm Package"],
+    "techStack": ["React", "TypeScript", "npm Package"],
     "claudeInfo": {
       "method": "direct",
       "summary": "react-stable-timeline.claudeInfo.summary"
@@ -45,7 +45,7 @@
     "projectType": "boj-snippets.overview.projectType",
     "period": "2026.04",
     "screenshots": [{ "src": "/images/bojSnippets/Icon.png", "alt": "BOJ Snippets Thumbnail" }],
-    "techStack": ["Chrome Extension", "Manifest V3", "JavaScript"],
+    "techStack": ["Chrome Extension", "JavaScript"],
     "claudeInfo": {
       "method": "direct",
       "summary": "boj-snippets.claudeInfo.summary"
@@ -87,7 +87,7 @@
     "projectType": "mrnsg.overview.projectType",
     "period": "2025.01",
     "screenshots": [{ "src": "/images/mrnsg/Icon.svg", "alt": "mogiyoon-react-native-simple-grid Thumbnail" }],
-    "techStack": ["TypeScript"]
+    "techStack": ["TypeScript", "npm Package"]
   },
   {
     "id": "teacher-test",
@@ -96,6 +96,6 @@
     "projectType": "teacher-test.overview.projectType",
     "period": "2024.01 ~ 2024.02",
     "screenshots": [{ "src": "/images/teacherTest/Icon.png", "alt": "Tea Time Thumbnail" }],
-    "techStack": ["Flutter", "Provider", "Material Design", "Firebase"]
+    "techStack": ["Flutter", "Provider", "Firebase"]
   }
 ]

--- a/public/locales/en/projects.json
+++ b/public/locales/en/projects.json
@@ -6,6 +6,12 @@
     "hint": "Flips every 2 seconds."
   },
   "preparingProjectSubtitle": "Projects currently in progress",
+  "techFilter": {
+    "title": "Tech Stack Filter",
+    "searchPlaceholder": "Search stacks",
+    "empty": "No matching stacks",
+    "noProjects": "No projects use the selected stacks"
+  },
   "aiDevKit": {
     "title": "AI DevKit",
     "subtitle": "AI development tool index",

--- a/public/locales/ko/projects.json
+++ b/public/locales/ko/projects.json
@@ -6,6 +6,12 @@
     "hint": "2초 간격 앞뒤 회전"
   },
   "preparingProjectSubtitle": "현재 준비 중인 프로젝트 목록",
+  "techFilter": {
+    "title": "기술 스택 필터",
+    "searchPlaceholder": "스택 검색",
+    "empty": "일치하는 스택 없음",
+    "noProjects": "선택한 스택을 사용하는 프로젝트 없음"
+  },
   "aiDevKit": {
     "title": "AI DevKit",
     "subtitle": "AI 개발 도구 목록",

--- a/src/components/ProjectsSidebar.tsx
+++ b/src/components/ProjectsSidebar.tsx
@@ -3,21 +3,26 @@ import { motion } from 'framer-motion';
 
 import { PROJECT_CARD_EASE } from '../hooks/useProjectGridEntrance';
 import type { ProjectDevKitCardData, ProjectDevKitId } from '../hooks/useProjectDevKitItems';
-import { useMediaQuery } from '../hooks/useMediaQuery';
 import type { ProjectSummary } from '../types';
 import AiDevKitCard from './AiDevKitCard';
 import ProjectFlipPreviewCard from './ProjectFlipPreviewCard';
 import StickySectionSidebar from './StickySectionSidebar';
+import TechStackFilterCard from './TechStackFilterCard';
 
 interface ProjectsSidebarProps {
     title: string;
     subtitle: string;
     projects: ProjectSummary[];
     hasPlayedProjectEntrance: boolean;
-    showAiDevKit: boolean;
     devKitTitle: string;
     devKitItems: ProjectDevKitCardData[];
     onSelectDevKit: (id: ProjectDevKitId) => void;
+    stackFilterTitle: string;
+    stackSearchPlaceholder: string;
+    stackEmptyText: string;
+    stacks: string[];
+    selectedStacks: Set<string>;
+    onToggleStack: (stack: string) => void;
 }
 
 const ProjectsSidebar: React.FC<ProjectsSidebarProps> = ({
@@ -25,15 +30,16 @@ const ProjectsSidebar: React.FC<ProjectsSidebarProps> = ({
     subtitle,
     projects,
     hasPlayedProjectEntrance,
-    showAiDevKit,
     devKitTitle,
     devKitItems,
     onSelectDevKit,
+    stackFilterTitle,
+    stackSearchPlaceholder,
+    stackEmptyText,
+    stacks,
+    selectedStacks,
+    onToggleStack,
 }) => {
-    // Tailwind `lg` (1024px) 기준. 데스크톱은 카드 entrance 후 AI DevKit 이 blur+scale 로
-    // 등장하지만, 모바일은 처음부터 마운트해 애니메이션 없이 노출 (피드백 반영).
-    const isDesktop = useMediaQuery('(min-width: 1024px)');
-
     const devKitCardBlock = (
         <div className="rounded-card bg-surface p-4 shadow-lg sm:p-5">
             <div className="mb-4">
@@ -60,6 +66,25 @@ const ProjectsSidebar: React.FC<ProjectsSidebarProps> = ({
         </div>
     );
 
+    // 사이드바 도구 카드 묶음 (AI DevKit + 기술 스택 필터) — 애니메이션 없이 즉시 노출
+    const toolCardsBlock = (
+        <>
+            {devKitCardBlock}
+            {stacks.length > 0 && (
+                <div className="mt-8">
+                    <TechStackFilterCard
+                        title={stackFilterTitle}
+                        searchPlaceholder={stackSearchPlaceholder}
+                        emptyText={stackEmptyText}
+                        stacks={stacks}
+                        selectedStacks={selectedStacks}
+                        onToggleStack={onToggleStack}
+                    />
+                </div>
+            )}
+        </>
+    );
+
     return (
         <StickySectionSidebar title={title} subtitle={subtitle}>
             {projects.length > 0 && (
@@ -72,24 +97,9 @@ const ProjectsSidebar: React.FC<ProjectsSidebarProps> = ({
                 </motion.div>
             )}
 
-            {isDesktop ? (
-                // 데스크톱: 카드 entrance 후 blur+scale 등장
-                showAiDevKit && (
-                    <motion.div
-                        initial={{ opacity: 0, y: 36, scale: 0.98, filter: 'blur(10px)' }}
-                        animate={{ opacity: 1, y: 0, scale: 1, filter: 'blur(0px)' }}
-                        transition={{ duration: 0.55, ease: PROJECT_CARD_EASE }}
-                        className={projects.length > 0 ? "mt-8" : undefined}
-                    >
-                        {devKitCardBlock}
-                    </motion.div>
-                )
-            ) : (
-                // 모바일: 처음부터 마운트, 애니메이션 없음
-                <div className={projects.length > 0 ? "mt-8" : undefined}>
-                    {devKitCardBlock}
-                </div>
-            )}
+            <div className={projects.length > 0 ? "mt-8" : undefined}>
+                {toolCardsBlock}
+            </div>
         </StickySectionSidebar>
     );
 };

--- a/src/components/ProjectsSidebar.tsx
+++ b/src/components/ProjectsSidebar.tsx
@@ -66,12 +66,11 @@ const ProjectsSidebar: React.FC<ProjectsSidebarProps> = ({
         </div>
     );
 
-    // 사이드바 도구 카드 묶음 (AI DevKit + 기술 스택 필터) — 애니메이션 없이 즉시 노출
+    // 사이드바 도구 카드 묶음 (기술 스택 필터 아코디언 + AI DevKit) — 애니메이션 없이 즉시 노출
     const toolCardsBlock = (
         <>
-            {devKitCardBlock}
             {stacks.length > 0 && (
-                <div className="mt-8">
+                <div className="mb-8">
                     <TechStackFilterCard
                         title={stackFilterTitle}
                         searchPlaceholder={stackSearchPlaceholder}
@@ -82,6 +81,7 @@ const ProjectsSidebar: React.FC<ProjectsSidebarProps> = ({
                     />
                 </div>
             )}
+            {devKitCardBlock}
         </>
     );
 

--- a/src/components/TechStackFilterCard.tsx
+++ b/src/components/TechStackFilterCard.tsx
@@ -1,6 +1,10 @@
 import React, { useMemo, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
 
+import { useDisclosure } from '../hooks/useDisclosure';
+import { collapseVerticalPreset } from '../utils/motionPresets';
 import Chip from './primitives/Chip';
+import RotatingChevron from './primitives/RotatingChevron';
 
 interface TechStackFilterCardProps {
     title: string;
@@ -19,6 +23,8 @@ const TechStackFilterCard: React.FC<TechStackFilterCardProps> = ({
     selectedStacks,
     onToggleStack,
 }) => {
+    // 기본 접힘 아코디언 — 필요할 때만 펼쳐서 사용
+    const { isOpen, toggle } = useDisclosure(false);
     const [query, setQuery] = useState('');
     const normalizedQuery = query.trim().toLowerCase();
 
@@ -32,45 +38,61 @@ const TechStackFilterCard: React.FC<TechStackFilterCardProps> = ({
 
     return (
         <div className="rounded-card bg-surface p-4 shadow-lg sm:p-5">
-            <div className="mb-4">
-                <span className="text-[11px] font-semibold uppercase tracking-[0.2em] text-content-muted">
-                    Tech Stack
-                </span>
-                <div className="mt-1 flex flex-wrap items-center justify-center gap-2 lg:justify-start">
-                    <h3 className="text-lg font-bold text-title">
-                        {title}
-                    </h3>
+            <button
+                type="button"
+                onClick={toggle}
+                aria-expanded={isOpen}
+                className="flex w-full items-center justify-between gap-2 text-left"
+            >
+                <div>
+                    <span className="text-[11px] font-semibold uppercase tracking-[0.2em] text-content-muted">
+                        Tech Stack
+                    </span>
+                    <div className="mt-1 flex flex-wrap items-center justify-center gap-2 lg:justify-start">
+                        <h3 className="text-lg font-bold text-title">
+                            {title}
+                        </h3>
+                    </div>
                 </div>
-            </div>
-            <input
-                type="search"
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-                placeholder={searchPlaceholder}
-                aria-label={searchPlaceholder}
-                className="w-full rounded-full border border-line bg-surface px-3.5 py-1.5 text-sm text-content-strong placeholder:text-content-muted focus:border-accent-500 focus:outline-none"
-            />
-            <div className="mt-3 flex flex-wrap justify-center gap-1.5 lg:justify-start">
-                {visibleStacks.map((stack) => (
-                    <button
-                        key={stack}
-                        type="button"
-                        onClick={() => onToggleStack(stack)}
-                        aria-pressed={selectedStacks.has(stack)}
-                        className="rounded-full"
-                    >
-                        <Chip
-                            tone={selectedStacks.has(stack) ? 'accentSolid' : 'outlined'}
-                            size="md"
-                        >
-                            {stack}
-                        </Chip>
-                    </button>
-                ))}
-                {visibleStacks.length === 0 && (
-                    <p className="text-xs text-content-muted">{emptyText}</p>
+                <div className="text-content-muted">
+                    <RotatingChevron isRotated={isOpen} size="md" />
+                </div>
+            </button>
+            <AnimatePresence initial={false}>
+                {isOpen && (
+                    <motion.div key="body" {...collapseVerticalPreset()}>
+                        <input
+                            type="search"
+                            value={query}
+                            onChange={(event) => setQuery(event.target.value)}
+                            placeholder={searchPlaceholder}
+                            aria-label={searchPlaceholder}
+                            className="mt-4 w-full rounded-full border border-line bg-surface px-3.5 py-1.5 text-sm text-content-strong placeholder:text-content-muted focus:border-accent-500 focus:outline-none"
+                        />
+                        <div className="mt-3 flex flex-wrap justify-center gap-1.5 lg:justify-start">
+                            {visibleStacks.map((stack) => (
+                                <button
+                                    key={stack}
+                                    type="button"
+                                    onClick={() => onToggleStack(stack)}
+                                    aria-pressed={selectedStacks.has(stack)}
+                                    className="rounded-full"
+                                >
+                                    <Chip
+                                        tone={selectedStacks.has(stack) ? 'accentSolid' : 'outlined'}
+                                        size="md"
+                                    >
+                                        {stack}
+                                    </Chip>
+                                </button>
+                            ))}
+                            {visibleStacks.length === 0 && (
+                                <p className="text-xs text-content-muted">{emptyText}</p>
+                            )}
+                        </div>
+                    </motion.div>
                 )}
-            </div>
+            </AnimatePresence>
         </div>
     );
 };

--- a/src/components/TechStackFilterCard.tsx
+++ b/src/components/TechStackFilterCard.tsx
@@ -1,0 +1,78 @@
+import React, { useMemo, useState } from 'react';
+
+import Chip from './primitives/Chip';
+
+interface TechStackFilterCardProps {
+    title: string;
+    searchPlaceholder: string;
+    emptyText: string;
+    stacks: string[];
+    selectedStacks: Set<string>;
+    onToggleStack: (stack: string) => void;
+}
+
+const TechStackFilterCard: React.FC<TechStackFilterCardProps> = ({
+    title,
+    searchPlaceholder,
+    emptyText,
+    stacks,
+    selectedStacks,
+    onToggleStack,
+}) => {
+    const [query, setQuery] = useState('');
+    const normalizedQuery = query.trim().toLowerCase();
+
+    const visibleStacks = useMemo(
+        () =>
+            normalizedQuery
+                ? stacks.filter((stack) => stack.toLowerCase().includes(normalizedQuery))
+                : stacks,
+        [stacks, normalizedQuery],
+    );
+
+    return (
+        <div className="rounded-card bg-surface p-4 shadow-lg sm:p-5">
+            <div className="mb-4">
+                <span className="text-[11px] font-semibold uppercase tracking-[0.2em] text-content-muted">
+                    Tech Stack
+                </span>
+                <div className="mt-1 flex flex-wrap items-center justify-center gap-2 lg:justify-start">
+                    <h3 className="text-lg font-bold text-title">
+                        {title}
+                    </h3>
+                </div>
+            </div>
+            <input
+                type="search"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder={searchPlaceholder}
+                aria-label={searchPlaceholder}
+                className="w-full rounded-full border border-line bg-surface px-3.5 py-1.5 text-sm text-content-strong placeholder:text-content-muted focus:border-accent-500 focus:outline-none"
+            />
+            <div className="mt-3 flex flex-wrap justify-center gap-1.5 lg:justify-start">
+                {visibleStacks.map((stack) => (
+                    <button
+                        key={stack}
+                        type="button"
+                        onClick={() => onToggleStack(stack)}
+                        aria-pressed={selectedStacks.has(stack)}
+                        className="rounded-full"
+                    >
+                        <Chip
+                            tone={selectedStacks.has(stack) ? 'accentSolid' : 'outlined'}
+                            size="md"
+                        >
+                            {stack}
+                        </Chip>
+                    </button>
+                ))}
+                {visibleStacks.length === 0 && (
+                    <p className="text-xs text-content-muted">{emptyText}</p>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default TechStackFilterCard;

--- a/src/hooks/useProjectGridEntrance.test.tsx
+++ b/src/hooks/useProjectGridEntrance.test.tsx
@@ -176,42 +176,6 @@ describe('useProjectGridEntrance', () => {
         expect(result.current.hasPlayedProjectEntrance).toBe(true);
     });
 
-    it('showAiDevKit becomes true after a delay scaled by projects.length once entrance has played', async () => {
-        inViewState.current = true;
-        const projects = [buildProject('alpha'), buildProject('beta'), buildProject('gamma')];
-
-        const { result, rerender } = renderHook(
-            ({ projects: p }) => useProjectGridEntrance({ projects: p, selectedId: null }),
-            { initialProps: { projects: [] as ProjectSummary[] } },
-        );
-
-        attachGridAndCards(result, projects);
-
-        await act(async () => {
-            rerender({ projects });
-        });
-
-        await act(async () => {
-            await vi.advanceTimersByTimeAsync(32);
-        });
-
-        expect(result.current.hasPlayedProjectEntrance).toBe(true);
-
-        // delay = (0.08 + (3-1)*0.05 + 1.05) * 1000 = 1230ms
-        const expectedDelay = (0.08 + (projects.length - 1) * 0.05 + 1.05) * 1000;
-
-        // Just before the timer fires
-        await act(async () => {
-            await vi.advanceTimersByTimeAsync(expectedDelay - 10);
-        });
-        expect(result.current.showAiDevKit).toBe(false);
-
-        await act(async () => {
-            await vi.advanceTimersByTimeAsync(20);
-        });
-        expect(result.current.showAiDevKit).toBe(true);
-    });
-
     it('cardVariants.cluster returns offset-driven {x, y, zIndex} when offsets exist', async () => {
         const projects = [buildProject('alpha'), buildProject('beta')];
         const { result, rerender } = renderHook(
@@ -278,12 +242,11 @@ describe('useProjectGridEntrance', () => {
         expect(otherExit.opacity).toBe(0);
     });
 
-    it('removes the resize listener and clears timers on unmount', async () => {
+    it('removes the resize listener on unmount', async () => {
         inViewState.current = true;
         const projects = [buildProject('alpha')];
 
         const removeSpy = vi.spyOn(window, 'removeEventListener');
-        const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout');
 
         const { result, rerender, unmount } = renderHook(
             ({ projects: p }) => useProjectGridEntrance({ projects: p, selectedId: null }),
@@ -296,7 +259,6 @@ describe('useProjectGridEntrance', () => {
             rerender({ projects });
         });
 
-        // Run through the entrance so that the showAiDevKit setTimeout is scheduled
         await act(async () => {
             await vi.advanceTimersByTimeAsync(32);
         });
@@ -304,6 +266,5 @@ describe('useProjectGridEntrance', () => {
         unmount();
 
         expect(removeSpy).toHaveBeenCalledWith('resize', expect.any(Function));
-        expect(clearTimeoutSpy).toHaveBeenCalled();
     });
 });

--- a/src/hooks/useProjectGridEntrance.ts
+++ b/src/hooks/useProjectGridEntrance.ts
@@ -30,7 +30,6 @@ export const useProjectGridEntrance = ({
 
     const [projectCardOffsets, setProjectCardOffsets] = useState<Record<string, ProjectCardOffset>>({});
     const [hasPlayedProjectEntrance, setHasPlayedProjectEntrance] = useState(false);
-    const [showAiDevKit, setShowAiDevKit] = useState(false);
 
     useLayoutEffect(() => {
         if (projects.length === 0) return;
@@ -91,20 +90,6 @@ export const useProjectGridEntrance = ({
         };
     }, [projectCardOffsetsReady, hasPlayedProjectEntrance]);
 
-    useEffect(() => {
-        if (!hasPlayedProjectEntrance || showAiDevKit) return;
-
-        const lastCardDelay = 0.08 + Math.max(projects.length - 1, 0) * 0.05;
-        const revealDelayMs = (lastCardDelay + 1.05) * 1000;
-        const timeoutId = window.setTimeout(() => {
-            setShowAiDevKit(true);
-        }, revealDelayMs);
-
-        return () => {
-            window.clearTimeout(timeoutId);
-        };
-    }, [hasPlayedProjectEntrance, projects.length, showAiDevKit]);
-
     // 카드 진입 cluster 상태. filter: blur 는 모바일 GPU 에서 컴포지터를 강제로 광역 재합성하게 만들어
     // staggered 다중 카드 시 끊김이 두드러지므로 제거. opacity + scale + translate 조합만 사용해
     // GPU 친화적인 transform/composite 경로로만 애니메이션한다.
@@ -163,7 +148,6 @@ export const useProjectGridEntrance = ({
         projectCardRefs,
         projectCardOffsetsReady,
         hasPlayedProjectEntrance,
-        showAiDevKit,
         cardVariants,
     };
 };

--- a/src/sections/home/ProjectsSection.test.tsx
+++ b/src/sections/home/ProjectsSection.test.tsx
@@ -119,13 +119,11 @@ vi.mock('../../components/ProjectsSidebar', () => ({
     projects,
     devKitItems,
     hasPlayedProjectEntrance,
-    showAiDevKit,
     onSelectDevKit,
   }: {
     projects: { id: string }[];
     devKitItems: { id: string }[];
     hasPlayedProjectEntrance: boolean;
-    showAiDevKit: boolean;
     onSelectDevKit: (id: string) => void;
   }) =>
     React.createElement(
@@ -135,7 +133,6 @@ vi.mock('../../components/ProjectsSidebar', () => ({
         'data-projects-count': String(projects.length),
         'data-devkit-count': String(devKitItems.length),
         'data-has-played': String(hasPlayedProjectEntrance),
-        'data-show-aidevkit': String(showAiDevKit),
       },
       devKitItems.map((item) =>
         React.createElement(
@@ -221,7 +218,6 @@ beforeEach(() => {
     projectCardRefs: { current: {} },
     projectCardOffsetsReady: true,
     hasPlayedProjectEntrance: true,
-    showAiDevKit: true,
     cardVariants: {},
   });
 
@@ -315,7 +311,7 @@ describe('ProjectsSection', () => {
     expect(navigateMock).toHaveBeenCalledWith('/project/beta');
   });
 
-  it('passes projects, devKitItems, hasPlayedProjectEntrance, and showAiDevKit to ProjectsSidebar', () => {
+  it('passes projects, devKitItems, and hasPlayedProjectEntrance to ProjectsSidebar', () => {
     useProjectListsMock.mockReturnValue({
       projects: [baseProject('a'), baseProject('b')],
       preparingProjects: [],
@@ -326,7 +322,6 @@ describe('ProjectsSection', () => {
       projectCardRefs: { current: {} },
       projectCardOffsetsReady: true,
       hasPlayedProjectEntrance: false,
-      showAiDevKit: false,
       cardVariants: {},
     });
 
@@ -336,7 +331,6 @@ describe('ProjectsSection', () => {
     expect(sidebar.getAttribute('data-projects-count')).toBe('2');
     expect(sidebar.getAttribute('data-devkit-count')).toBe('3');
     expect(sidebar.getAttribute('data-has-played')).toBe('false');
-    expect(sidebar.getAttribute('data-show-aidevkit')).toBe('false');
   });
 
   it('AiDevKitModal receives null item until a dev-kit card is selected, then the matching item', () => {

--- a/src/sections/home/ProjectsSection.tsx
+++ b/src/sections/home/ProjectsSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
@@ -11,6 +11,7 @@ import StickySectionSidebar from "../../components/StickySectionSidebar";
 import { useProjectDevKitItems, type ProjectDevKitId } from '../../hooks/useProjectDevKitItems';
 import { useProjectGridEntrance } from '../../hooks/useProjectGridEntrance';
 import { useProjectLists } from '../../hooks/useProjectLists';
+import { useToggleSet } from '../../hooks/useToggleSet';
 import type { ProjectSummary } from '../../types';
 import { durations } from '../../design-tokens';
 
@@ -30,13 +31,35 @@ const ProjectsSection: React.FC = () => {
         projectCardRefs,
         projectCardOffsetsReady,
         hasPlayedProjectEntrance,
-        showAiDevKit,
         cardVariants,
     } = useProjectGridEntrance({
         projects,
         selectedId,
     });
     const devKitItems = useProjectDevKitItems();
+    const selectedStacks = useToggleSet<string>();
+
+    // 프로젝트들에 태그된 스택을 사용 빈도순(동률이면 이름순)으로 나열
+    const stackOptions = useMemo(() => {
+        const counts = new Map<string, number>();
+        for (const project of projects) {
+            for (const tech of project.techStack ?? []) {
+                counts.set(tech, (counts.get(tech) ?? 0) + 1);
+            }
+        }
+        return [...counts.keys()].sort((a, b) => {
+            const countDiff = (counts.get(b) ?? 0) - (counts.get(a) ?? 0);
+            return countDiff !== 0 ? countDiff : a.localeCompare(b);
+        });
+    }, [projects]);
+
+    // 선택된 스택을 모두 포함하는 프로젝트만 노출 (선택 없으면 전체)
+    const visibleProjects = useMemo(() => {
+        if (selectedStacks.ids.size === 0) return projects;
+        return projects.filter((project) =>
+            [...selectedStacks.ids].every((stack) => project.techStack?.includes(stack)),
+        );
+    }, [projects, selectedStacks.ids]);
 
     const handleCardClick = (projectId: string) => {
         setSelectedId(projectId);
@@ -76,10 +99,15 @@ const ProjectsSection: React.FC = () => {
                                 subtitle={t('projectSubtitle', { ns: 'projects' })}
                                 projects={projects}
                                 hasPlayedProjectEntrance={hasPlayedProjectEntrance}
-                                showAiDevKit={showAiDevKit}
                                 devKitTitle={t('aiDevKit.title', { ns: 'projects' })}
                                 devKitItems={devKitItems}
                                 onSelectDevKit={setSelectedDevKitId}
+                                stackFilterTitle={t('techFilter.title', { ns: 'projects' })}
+                                stackSearchPlaceholder={t('techFilter.searchPlaceholder', { ns: 'projects' })}
+                                stackEmptyText={t('techFilter.empty', { ns: 'projects' })}
+                                stacks={stackOptions}
+                                selectedStacks={selectedStacks.ids}
+                                onToggleStack={selectedStacks.toggle}
                             />
                         </motion.div>
 
@@ -89,7 +117,7 @@ const ProjectsSection: React.FC = () => {
                                 className="grid grid-cols-2 gap-5 md:grid-cols-3 lg:px-0 xl:grid-cols-3"
                                 style={{ opacity: projectCardOffsetsReady ? 1 : 0 }}
                             >
-                                {projects.map((project, index) => (
+                                {visibleProjects.map((project, index) => (
                                     <motion.div
                                         key={project.id}
                                         ref={(element) => {
@@ -106,6 +134,11 @@ const ProjectsSection: React.FC = () => {
                                     </motion.div>
                                 ))}
                             </div>
+                            {visibleProjects.length === 0 && (
+                                <p className="py-10 text-center text-sm text-content-muted">
+                                    {t('techFilter.noProjects', { ns: 'projects' })}
+                                </p>
+                            )}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Add `TechStackFilterCard` below the AI DevKit card in the projects sidebar: a search input plus toggleable chips listing every stack tagged across projects
- Clicking chips filters the project card grid to projects containing all selected stacks (multi-select AND), with an empty-state message when nothing matches
- Render AI DevKit and the filter card immediately without entrance animation; remove the now-unused `showAiDevKit` state/timer from `useProjectGridEntrance`
- Curate `projects-list.json` techStack based on Korean job board research (Saramin, JobKorea, Wanted, Jumpit): keep stacks used as hiring keywords, drop library-level names replaced by parent keywords, keep identity keywords (claude CLI, MCP, npm Package, Chrome Extension, AR/VR, ffmpeg, Google Vision API) as exceptions
- Document the techStack listing criteria in CLAUDE.md for future project registration; add `npm Package` to mrnsg

## Test plan
- `npx tsc --noEmit` passes
- `npx vitest run` — 32 files, 199 passed / 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)