### PR TITLE
release: 작은 화면 기술 스택 필터 플로팅 버튼 + 플로팅 버튼 가림 방지 여백

### DIFF
--- a/public/locales/en/projects.json
+++ b/public/locales/en/projects.json
@@ -12,7 +12,8 @@
     "title": "Tech Stack Filter",
     "searchPlaceholder": "Search stacks",
     "empty": "No matching stacks",
-    "noProjects": "No projects use the selected stacks"
+    "noProjects": "No projects use the selected stacks",
+    "close": "Close filter"
   },
   "aiDevKit": {
     "title": "AI DevKit",

--- a/public/locales/ko/projects.json
+++ b/public/locales/ko/projects.json
@@ -12,7 +12,8 @@
     "title": "기술 스택 필터",
     "searchPlaceholder": "스택 검색",
     "empty": "일치하는 스택 없음",
-    "noProjects": "선택한 스택을 사용하는 프로젝트 없음"
+    "noProjects": "선택한 스택을 사용하는 프로젝트 없음",
+    "close": "필터 닫기"
   },
   "aiDevKit": {
     "title": "AI DevKit",

--- a/src/components/ProjectsSidebar.tsx
+++ b/src/components/ProjectsSidebar.tsx
@@ -2,14 +2,16 @@ import React, { useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 
 import { PROJECT_CARD_EASE } from '../hooks/useProjectGridEntrance';
+import { useDisclosure } from '../hooks/useDisclosure';
 import { useMediaQuery } from '../hooks/useMediaQuery';
 import { collapseVerticalPreset } from '../utils/motionPresets';
 import type { ProjectDevKitCardData, ProjectDevKitId } from '../hooks/useProjectDevKitItems';
 import type { ProjectSummary } from '../types';
 import AiDevKitCard from './AiDevKitCard';
+import ModalShell from './primitives/ModalShell';
 import ProjectFlipPreviewCard from './ProjectFlipPreviewCard';
 import StickySectionSidebar from './StickySectionSidebar';
-import TechStackFilterCard from './TechStackFilterCard';
+import TechStackFilterCard, { TechStackFilterPanel } from './TechStackFilterCard';
 
 interface ProjectsSidebarProps {
     title: string;
@@ -20,6 +22,7 @@ interface ProjectsSidebarProps {
     devKitItems: ProjectDevKitCardData[];
     onSelectDevKit: (id: ProjectDevKitId) => void;
     stackFilterTitle: string;
+    stackFilterCloseLabel: string;
     stackSearchPlaceholder: string;
     stackEmptyText: string;
     stacks: string[];
@@ -37,6 +40,7 @@ const ProjectsSidebar: React.FC<ProjectsSidebarProps> = ({
     devKitItems,
     onSelectDevKit,
     stackFilterTitle,
+    stackFilterCloseLabel,
     stackSearchPlaceholder,
     stackEmptyText,
     stacks,
@@ -50,6 +54,14 @@ const ProjectsSidebar: React.FC<ProjectsSidebarProps> = ({
     const [isStackFilterOpen, setIsStackFilterOpen] = useState(stackFilterDefaultOpen);
     const isDesktop = useMediaQuery('(min-width: 1024px)'); // Tailwind lg
     const showFlipPreview = projects.length > 0 && !(isDesktop && isStackFilterOpen);
+
+    // 작은 화면(lg 미만, 사이드바가 세로 적층되는 레이아웃)에서는 아코디언 카드 대신
+    // 우하단 플로팅 버튼 + 모달로 필터를 제공한다 (이력서 편집 버튼과 동일 패턴).
+    const {
+        isOpen: isMobileFilterOpen,
+        open: openMobileFilter,
+        close: closeMobileFilter,
+    } = useDisclosure(false);
     const devKitCardBlock = (
         <div className="rounded-card bg-surface p-4 shadow-lg sm:p-5">
             <div className="mb-4">
@@ -77,10 +89,11 @@ const ProjectsSidebar: React.FC<ProjectsSidebarProps> = ({
     );
 
     // 사이드바 도구 카드 묶음 (기술 스택 필터 아코디언 + AI DevKit) — 애니메이션 없이 즉시 노출
+    // 필터 아코디언 카드는 데스크톱(lg+) 전용. lg 미만은 아래 플로팅 버튼 + 모달로 대체
     const toolCardsBlock = (
         <>
             {stacks.length > 0 && (
-                <div className="mb-8">
+                <div className="mb-8 hidden lg:block">
                     <TechStackFilterCard
                         title={stackFilterTitle}
                         searchPlaceholder={stackSearchPlaceholder}
@@ -98,28 +111,97 @@ const ProjectsSidebar: React.FC<ProjectsSidebarProps> = ({
     );
 
     return (
-        <StickySectionSidebar title={title} subtitle={subtitle}>
-            <AnimatePresence initial={false}>
-                {showFlipPreview && (
-                    <motion.div key="flip-preview" {...collapseVerticalPreset()}>
-                        {/* 카드-필터 간격(pb-8)은 컬랩스 컨테이너 안에 둬야 높이와 함께 접힌다 */}
-                        <div className="pb-8">
-                            <motion.div
-                                initial={{ opacity: 0, y: 18 }}
-                                animate={hasPlayedProjectEntrance ? { opacity: 1, y: 0 } : { opacity: 0, y: 18 }}
-                                transition={{ duration: 0.45, ease: PROJECT_CARD_EASE }}
-                            >
-                                <ProjectFlipPreviewCard projects={projects} />
-                            </motion.div>
-                        </div>
-                    </motion.div>
-                )}
-            </AnimatePresence>
+        <>
+            <StickySectionSidebar title={title} subtitle={subtitle}>
+                <AnimatePresence initial={false}>
+                    {showFlipPreview && (
+                        <motion.div key="flip-preview" {...collapseVerticalPreset()}>
+                            {/* 카드-필터 간격(pb-8)은 컬랩스 컨테이너 안에 둬야 높이와 함께 접힌다 */}
+                            <div className="pb-8">
+                                <motion.div
+                                    initial={{ opacity: 0, y: 18 }}
+                                    animate={hasPlayedProjectEntrance ? { opacity: 1, y: 0 } : { opacity: 0, y: 18 }}
+                                    transition={{ duration: 0.45, ease: PROJECT_CARD_EASE }}
+                                >
+                                    <ProjectFlipPreviewCard projects={projects} />
+                                </motion.div>
+                            </div>
+                        </motion.div>
+                    )}
+                </AnimatePresence>
 
-            <div>
-                {toolCardsBlock}
-            </div>
-        </StickySectionSidebar>
+                <div>
+                    {toolCardsBlock}
+                </div>
+            </StickySectionSidebar>
+
+            {/* 작은 화면 전용 필터 플로팅 버튼 (이력서 편집 버튼과 동일 패턴) */}
+            {stacks.length > 0 && (
+                <button
+                    type="button"
+                    onClick={openMobileFilter}
+                    className="fixed bottom-5 right-5 z-40 inline-flex items-center gap-2 rounded-full bg-slate-900 px-5 py-3.5 text-sm font-semibold text-white shadow-xl lg:hidden"
+                >
+                    <svg
+                        className="h-4 w-4"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                    >
+                        <path d="M22 3H2l8 9.46V19l4 2v-8.54L22 3z" />
+                    </svg>
+                    {stackFilterTitle}
+                    {selectedStacks.size > 0 && (
+                        <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-accent-500 px-1.5 text-xs font-bold leading-none">
+                            {selectedStacks.size}
+                        </span>
+                    )}
+                </button>
+            )}
+
+            <ModalShell
+                isOpen={isMobileFilterOpen}
+                onClose={closeMobileFilter}
+                backdropClassName="lg:hidden"
+                className="fixed inset-x-3 bottom-3 mx-auto flex max-h-[75vh] max-w-xl flex-col overflow-hidden p-4"
+                ariaLabelledBy="mobile-stack-filter-title"
+            >
+                <div className="flex shrink-0 items-center justify-between">
+                    <h2 id="mobile-stack-filter-title" className="text-lg font-bold text-title">
+                        {stackFilterTitle}
+                    </h2>
+                    <button
+                        type="button"
+                        onClick={closeMobileFilter}
+                        aria-label={stackFilterCloseLabel}
+                        className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-line bg-surface text-content-muted"
+                    >
+                        <svg
+                            className="h-4 w-4"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                        >
+                            <path d="M18 6 6 18M6 6l12 12" />
+                        </svg>
+                    </button>
+                </div>
+                <TechStackFilterPanel
+                    searchPlaceholder={stackSearchPlaceholder}
+                    emptyText={stackEmptyText}
+                    stacks={stacks}
+                    selectedStacks={selectedStacks}
+                    onToggleStack={onToggleStack}
+                    listMaxHeightClassName="max-h-[50vh]"
+                />
+            </ModalShell>
+        </>
     );
 };
 

--- a/src/components/TechStackFilterCard.tsx
+++ b/src/components/TechStackFilterCard.tsx
@@ -6,18 +6,84 @@ import { collapseVerticalPreset } from '../utils/motionPresets';
 import Chip from './primitives/Chip';
 import RotatingChevron from './primitives/RotatingChevron';
 
-interface TechStackFilterCardProps {
-    title: string;
+export interface TechStackFilterPanelProps {
     searchPlaceholder: string;
     emptyText: string;
     stacks: string[];
     selectedStacks: Set<string>;
     onToggleStack: (stack: string) => void;
+    /** 칩 목록 스크롤 영역의 max-height 클래스. 사이드바 카드는 기본값, 모바일 모달은 더 크게 override */
+    listMaxHeightClassName?: string;
+}
+
+interface TechStackFilterCardProps extends TechStackFilterPanelProps {
+    title: string;
     /** true 면 펼친 상태로 시작 (예: 스킬 칩에서 필터가 선택된 채 진입한 경우) */
     defaultOpen?: boolean;
     /** 아코디언 펼침/접힘이 바뀔 때 알림 (사이드바가 플립 프리뷰 카드 숨김에 사용) */
     onOpenChange?: (isOpen: boolean) => void;
 }
+
+/** 필터 본문 (검색 입력 + 스택 칩 목록). 사이드바 아코디언과 모바일 모달이 공유한다. */
+export const TechStackFilterPanel: React.FC<TechStackFilterPanelProps> = ({
+    searchPlaceholder,
+    emptyText,
+    stacks,
+    selectedStacks,
+    onToggleStack,
+    listMaxHeightClassName = 'max-h-52',
+}) => {
+    const [query, setQuery] = useState('');
+    const normalizedQuery = query.trim().toLowerCase();
+
+    const visibleStacks = useMemo(
+        () =>
+            normalizedQuery
+                ? stacks.filter((stack) => stack.toLowerCase().includes(normalizedQuery))
+                : stacks,
+        [stacks, normalizedQuery],
+    );
+
+    return (
+        <>
+            <input
+                type="search"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder={searchPlaceholder}
+                aria-label={searchPlaceholder}
+                className="mt-4 w-full rounded-full border border-line bg-surface px-3.5 py-1.5 text-sm text-content-strong placeholder:text-content-muted focus:border-accent-500 focus:outline-none"
+            />
+            {/* 칩 목록이 프로젝트 수에 비례해 자라므로 내부 스크롤로 제한한다.
+                max-h 는 칩 줄 높이에 안 떨어지는 값으로 잡아 마지막 줄이 반쯤 걸쳐 보이게 해
+                스크롤 가능한 영역임이 눈에 보이도록 한다. (sticky 사이드바가 뷰포트를
+                넘어 AI DevKit 카드까지 밀어내던 문제의 해결) */}
+            <div className={`mt-3 overflow-y-auto overscroll-contain pr-1 ${listMaxHeightClassName}`}>
+                <div className="flex flex-wrap justify-center gap-1.5 lg:justify-start">
+                    {visibleStacks.map((stack) => (
+                        <button
+                            key={stack}
+                            type="button"
+                            onClick={() => onToggleStack(stack)}
+                            aria-pressed={selectedStacks.has(stack)}
+                            className="rounded-full"
+                        >
+                            <Chip
+                                tone={selectedStacks.has(stack) ? 'accentSolid' : 'outlined'}
+                                size="md"
+                            >
+                                {stack}
+                            </Chip>
+                        </button>
+                    ))}
+                    {visibleStacks.length === 0 && (
+                        <p className="text-xs text-content-muted">{emptyText}</p>
+                    )}
+                </div>
+            </div>
+        </>
+    );
+};
 
 const TechStackFilterCard: React.FC<TechStackFilterCardProps> = ({
     title,
@@ -36,16 +102,6 @@ const TechStackFilterCard: React.FC<TechStackFilterCardProps> = ({
         onOpenChange?.(!isOpen);
         toggle();
     };
-    const [query, setQuery] = useState('');
-    const normalizedQuery = query.trim().toLowerCase();
-
-    const visibleStacks = useMemo(
-        () =>
-            normalizedQuery
-                ? stacks.filter((stack) => stack.toLowerCase().includes(normalizedQuery))
-                : stacks,
-        [stacks, normalizedQuery],
-    );
 
     return (
         <div className="rounded-card bg-surface p-4 shadow-lg sm:p-5">
@@ -72,41 +128,13 @@ const TechStackFilterCard: React.FC<TechStackFilterCardProps> = ({
             <AnimatePresence initial={false}>
                 {isOpen && (
                     <motion.div key="body" {...collapseVerticalPreset()}>
-                        <input
-                            type="search"
-                            value={query}
-                            onChange={(event) => setQuery(event.target.value)}
-                            placeholder={searchPlaceholder}
-                            aria-label={searchPlaceholder}
-                            className="mt-4 w-full rounded-full border border-line bg-surface px-3.5 py-1.5 text-sm text-content-strong placeholder:text-content-muted focus:border-accent-500 focus:outline-none"
+                        <TechStackFilterPanel
+                            searchPlaceholder={searchPlaceholder}
+                            emptyText={emptyText}
+                            stacks={stacks}
+                            selectedStacks={selectedStacks}
+                            onToggleStack={onToggleStack}
                         />
-                        {/* 칩 목록이 프로젝트 수에 비례해 자라므로 내부 스크롤로 제한한다.
-                            max-h 는 칩 줄 높이에 안 떨어지는 값으로 잡아 마지막 줄이 반쯤 걸쳐 보이게 해
-                            스크롤 가능한 영역임이 눈에 보이도록 한다. (sticky 사이드바가 뷰포트를
-                            넘어 AI DevKit 카드까지 밀어내던 문제의 해결) */}
-                        <div className="mt-3 max-h-52 overflow-y-auto overscroll-contain pr-1">
-                            <div className="flex flex-wrap justify-center gap-1.5 lg:justify-start">
-                                {visibleStacks.map((stack) => (
-                                    <button
-                                        key={stack}
-                                        type="button"
-                                        onClick={() => onToggleStack(stack)}
-                                        aria-pressed={selectedStacks.has(stack)}
-                                        className="rounded-full"
-                                    >
-                                        <Chip
-                                            tone={selectedStacks.has(stack) ? 'accentSolid' : 'outlined'}
-                                            size="md"
-                                        >
-                                            {stack}
-                                        </Chip>
-                                    </button>
-                                ))}
-                                {visibleStacks.length === 0 && (
-                                    <p className="text-xs text-content-muted">{emptyText}</p>
-                                )}
-                            </div>
-                        </div>
                     </motion.div>
                 )}
             </AnimatePresence>

--- a/src/pages/ResumePreviewPage/index.tsx
+++ b/src/pages/ResumePreviewPage/index.tsx
@@ -628,7 +628,8 @@ const ResumePreviewPage: React.FC = () => {
     <>
     {resumeSeo}
     <section className="min-h-screen bg-[#dfe5ec] print:bg-white">
-      <div className="mx-auto max-w-7xl px-4 pt-28 pb-10 print:px-0 print:pt-0">
+      {/* pb-24: xl 미만에서 편집 플로팅 버튼(fixed bottom-5)이 이력서 하단을 가리지 않도록 여백 확보 */}
+      <div className="mx-auto max-w-7xl px-4 pt-28 pb-24 xl:pb-10 print:px-0 print:pt-0 print:pb-10">
         <div data-print-hidden="true" className="mb-5 flex flex-wrap items-center justify-between gap-3">
           <div>
             <h1 className="text-3xl font-bold text-slate-950">{t("resume.heading")}</h1>

--- a/src/sections/home/ProjectsSection.tsx
+++ b/src/sections/home/ProjectsSection.tsx
@@ -146,7 +146,8 @@ const ProjectsSection: React.FC = () => {
     return (
         <>
             <section id="projects" className="min-h-screen pt-20">
-                <div className="mx-auto w-full max-w-7xl px-3 py-6 md:px-5 lg:px-8 animate-fade-in">
+                {/* pb-24: lg 미만에서 필터 플로팅 버튼(fixed bottom-5)이 마지막 카드 행을 가리지 않도록 여백 확보 */}
+                <div className="mx-auto w-full max-w-7xl px-3 pt-6 pb-24 md:px-5 lg:px-8 lg:pb-6 animate-fade-in">
                     <div className="lg:grid lg:grid-cols-[minmax(220px,280px)_minmax(0,1fr)] lg:gap-10 xl:grid-cols-[minmax(240px,320px)_minmax(0,1fr)] xl:gap-14">
                         <motion.div
                             exit={sectionExitAnimation}
@@ -161,6 +162,7 @@ const ProjectsSection: React.FC = () => {
                                 devKitItems={devKitItems}
                                 onSelectDevKit={setSelectedDevKitId}
                                 stackFilterTitle={t('techFilter.title', { ns: 'projects' })}
+                                stackFilterCloseLabel={t('techFilter.close', { ns: 'projects' })}
                                 stackSearchPlaceholder={t('techFilter.searchPlaceholder', { ns: 'projects' })}
                                 stackEmptyText={t('techFilter.empty', { ns: 'projects' })}
                                 stacks={stackOptions}


### PR DESCRIPTION
## 개요

develop 의 변경 사항을 main 으로 반영함.

## 포함된 변경 (#118)

- 작은 화면(lg 미만)에서 기술 스택 필터를 사이드바 아코디언 대신 우하단 플로팅 버튼 + 하단 모달로 제공 (이력서 편집 버튼과 동일 패턴, 선택 개수 뱃지 포함)
- `TechStackFilterCard` 본문을 `TechStackFilterPanel` 로 분리해 데스크톱 아코디언과 모바일 모달이 공유
- 프로젝트 섹션(lg 미만)과 이력서 미리보기 페이지(xl 미만)에 하단 여백을 추가해 플로팅 버튼이 콘텐츠를 가리지 않도록 함 (인쇄 여백은 기존 유지)
- `techFilter.close` i18n 키 추가 (ko/en)

## 테스트

- `npx tsc --noEmit` 통과
- `npx vitest run` — 32개 파일 208개 테스트 전부 통과
- pre-push 빌드 및 프리렌더(11개 라우트) 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)