### PR TITLE
feat(resume): 이력서 빌더 프리셋 가져오기·내보내기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,9 @@ lerna-debug.log*
 *.docx
 # Blog drafts (local only)
 /blog/
+
+NohGiYoon.jpg
+
+# Resume personal data (presets contain phone/photo)
+docs/resume-presets/
+docs/resume-*.pdf

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -176,6 +176,9 @@
       "blog": "Blog",
       "github": "GitHub",
       "linkedin": "LinkedIn"
-    }
+    },
+    "importPreset": "Import preset",
+    "exportPreset": "Export preset",
+    "presetImportFailed": "Failed to read the preset file"
   }
 }

--- a/public/locales/ko/common.json
+++ b/public/locales/ko/common.json
@@ -176,6 +176,9 @@
       "blog": "기술 블로그",
       "github": "GitHub",
       "linkedin": "LinkedIn"
-    }
+    },
+    "importPreset": "프리셋 가져오기",
+    "exportPreset": "프리셋 내보내기",
+    "presetImportFailed": "프리셋 파일을 읽지 못했습니다"
   }
 }

--- a/src/pages/ResumePreviewPage/index.tsx
+++ b/src/pages/ResumePreviewPage/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {
@@ -7,6 +7,13 @@ import {
   type ResumeEditableBlock,
   type ResumeProjectEntry,
 } from "../../utils/resumePreview";
+import {
+  applyPresetToDraft,
+  buildPresetExport,
+  resolvePresetBlockIds,
+  resolvePresetProjectIds,
+  type ResumePreset,
+} from "../../utils/resumePreset";
 import Seo from "../../components/Seo";
 import { SEO_COPY, pickSeoLocale } from "../../seo-copy";
 import {
@@ -116,6 +123,40 @@ const ResumePreviewPage: React.FC = () => {
     reader.readAsDataURL(file);
     // 같은 파일을 다시 선택해도 change 가 발생하도록 입력값 초기화
     e.target.value = "";
+  };
+
+  // 프리셋 가져오기 — JSON 파일 하나로 블록 선택·문구·사진·연락처를 일괄 적용한다.
+  const presetInputRef = useRef<HTMLInputElement | null>(null);
+
+  const handlePresetImport = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file || !sourceData) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const preset = JSON.parse(String(reader.result)) as ResumePreset;
+        setDraft((prev) => (prev ? applyPresetToDraft(prev, preset) : prev));
+        resetSelectedBlockIds(resolvePresetBlockIds(sourceData, preset));
+        resetIncludedProjectIds(resolvePresetProjectIds(sourceData, preset));
+        if (preset.photo !== undefined) setPhotoDataUrl(preset.photo || null);
+      } catch {
+        window.alert(t("resume.presetImportFailed"));
+      }
+    };
+    reader.readAsText(file);
+    e.target.value = "";
+  };
+
+  const handlePresetExport = () => {
+    if (!draft) return;
+    const preset = buildPresetExport(draft, selectedBlockIds.ids, includedProjectIds.ids, photoDataUrl);
+    const blob = new Blob([JSON.stringify(preset, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "resume-preset.json";
+    link.click();
+    URL.revokeObjectURL(url);
   };
 
   const {
@@ -643,6 +684,27 @@ const ResumePreviewPage: React.FC = () => {
             >
               {t("resume.backToProfile")}
             </Link>
+            <input
+              ref={presetInputRef}
+              type="file"
+              accept="application/json"
+              className="hidden"
+              onChange={handlePresetImport}
+            />
+            <button
+              type="button"
+              onClick={() => presetInputRef.current?.click()}
+              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-800 shadow-sm"
+            >
+              {t("resume.importPreset")}
+            </button>
+            <button
+              type="button"
+              onClick={handlePresetExport}
+              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-800 shadow-sm"
+            >
+              {t("resume.exportPreset")}
+            </button>
             <button
               type="button"
               onClick={resetDraft}

--- a/src/utils/resumePreset.ts
+++ b/src/utils/resumePreset.ts
@@ -1,0 +1,109 @@
+import type { ResumeBuilderData } from "./resumePreview";
+
+/**
+ * 이력서 빌더 프리셋 — "프리셋 가져오기"로 불러오는 JSON의 스키마.
+ *
+ * - profile: draft.profile 에 얕게 병합. intro.bullets 는 index 지정 패치로 일부만 교체 가능
+ * - photo: 미리보기·인쇄에 쓸 사진 (data URL 또는 public 경로)
+ * - blocks.include / exclude: 블록 id 정확 일치 또는 제목 부분 일치로 기본 선택에 추가/제거
+ * - blocks.exact: 내보내기가 기록하는 정확한 선택 목록 (있으면 include/exclude 보다 우선)
+ * - projects: 포함할 개인 프로젝트 조정 (id 정확 일치)
+ */
+export type ResumePresetBulletPatch = {
+  index: number;
+  text: string;
+  bold?: string[];
+  links?: Array<{ text: string; url: string }>;
+};
+
+export type ResumePreset = {
+  profile?: Record<string, unknown> & {
+    intro?: { line?: string; bullets?: ResumePresetBulletPatch[] };
+  };
+  photo?: string;
+  blocks?: { exact?: string[]; include?: string[]; exclude?: string[] };
+  projects?: { exact?: string[]; include?: string[]; exclude?: string[] };
+};
+
+type FlatBlock = { id: string; title: string };
+
+const flattenBlocks = (data: ResumeBuilderData): FlatBlock[] => [
+  ...data.workExperience.flatMap((work) =>
+    work.projects.flatMap((project) =>
+      project.blocks.map((block) => ({ id: block.id, title: block.title })),
+    ),
+  ),
+  ...data.projects.flatMap((project) =>
+    project.blocks.map((block) => ({ id: block.id, title: block.title })),
+  ),
+];
+
+const matches = (block: FlatBlock, pattern: string) =>
+  block.id === pattern || block.title.includes(pattern);
+
+/** 프리셋의 blocks 지시를 기본 선택 목록에 적용해 최종 블록 id 목록을 만든다. */
+export const resolvePresetBlockIds = (
+  data: ResumeBuilderData,
+  preset: ResumePreset,
+): string[] => {
+  const blocks = flattenBlocks(data);
+  if (preset.blocks?.exact) {
+    return preset.blocks.exact.filter((id) => blocks.some((b) => b.id === id));
+  }
+  const ids = new Set(data.defaultSelectedBlockIds);
+  (preset.blocks?.include ?? []).forEach((pattern) => {
+    blocks.filter((b) => matches(b, pattern)).forEach((b) => ids.add(b.id));
+  });
+  (preset.blocks?.exclude ?? []).forEach((pattern) => {
+    blocks.filter((b) => matches(b, pattern)).forEach((b) => ids.delete(b.id));
+  });
+  return blocks.map((b) => b.id).filter((id) => ids.has(id));
+};
+
+/** 프리셋의 projects 지시를 기본 포함 목록에 적용한다. */
+export const resolvePresetProjectIds = (
+  data: ResumeBuilderData,
+  preset: ResumePreset,
+): string[] => {
+  if (preset.projects?.exact) return preset.projects.exact;
+  const ids = new Set(data.defaultIncludedProjectIds);
+  (preset.projects?.include ?? []).forEach((id) => ids.add(id));
+  (preset.projects?.exclude ?? []).forEach((id) => ids.delete(id));
+  return [...ids];
+};
+
+/** draft 에 프리셋 profile 을 병합한 새 draft 를 돌려준다 (원본 불변). */
+export const applyPresetToDraft = <T extends { profile: ResumeBuilderData["profile"] }>(
+  draft: T,
+  preset: ResumePreset,
+): T => {
+  if (!preset.profile) return draft;
+  const { intro: introPatch, ...profileRest } = preset.profile;
+  const profile = { ...draft.profile, ...profileRest } as ResumeBuilderData["profile"];
+  if (introPatch) {
+    const intro = { ...(profile as { intro?: { line?: string; bullets?: unknown[] } }).intro };
+    if (introPatch.line !== undefined) intro.line = introPatch.line;
+    if (introPatch.bullets) {
+      const bullets = [...((intro.bullets as ResumePresetBulletPatch[] | undefined) ?? [])];
+      introPatch.bullets.forEach(({ index, ...bullet }) => {
+        if (index >= 0 && index < bullets.length) bullets[index] = bullet as (typeof bullets)[number];
+      });
+      intro.bullets = bullets;
+    }
+    (profile as { intro?: unknown }).intro = intro;
+  }
+  return { ...draft, profile };
+};
+
+/** 현재 상태를 다시 가져올 수 있는 프리셋 JSON 으로 만든다 ("프리셋 내보내기"). */
+export const buildPresetExport = (
+  draft: { profile: ResumeBuilderData["profile"] },
+  selectedBlockIds: Iterable<string>,
+  includedProjectIds: Iterable<string>,
+  photo: string | null,
+): ResumePreset => ({
+  profile: draft.profile as unknown as ResumePreset["profile"],
+  ...(photo ? { photo } : {}),
+  blocks: { exact: [...selectedBlockIds] },
+  projects: { exact: [...includedProjectIds] },
+});


### PR DESCRIPTION
## 요약
- 이력서 빌더 툴바에 **프리셋 가져오기 / 내보내기** 버튼을 추가함
- 프리셋 JSON 파일 하나로 블록 선택·해제, 인트로 불릿 패치, 포함 프로젝트, 연락처, 사진을 일괄 적용함
- 내보내기는 현재 편집 상태를 동일 스키마 JSON으로 저장해 재현 가능하게 함

## 구현
- `src/utils/resumePreset.ts` (신규): 프리셋 스키마 타입 + 순수 함수
  - `blocks.include / exclude`: 블록 id 정확 일치 또는 제목 부분 일치 (경력·프로젝트 블록 모두 스캔)
  - `blocks.exact` / `projects.exact`: 내보내기가 기록하는 정확 목록 (있으면 우선)
  - `profile.intro.bullets`: index 지정 패치로 일부 불릿만 교체
- `ResumePreviewPage/index.tsx`: 숨김 file input + 버튼 2개, FileReader 로 JSON 파싱 후 기존 setter(setDraft / resetSelectedBlockIds / resetIncludedProjectIds / setPhotoDataUrl)로 적용
- i18n: `resume.importPreset / exportPreset / presetImportFailed` (ko·en)

## 개인정보
- 연락처·사진은 프리셋 파일에만 담김. 배포 데이터(resume-profile.json)는 변경 없음

## 검증
- `tsc --noEmit` 통과, 기존 이력서 테스트 11건 통과
- 헤드리스 크롬으로 프리셋 임포트 → 미리보기 반영(17개 항목 체크) → PDF 인쇄까지 E2E 확인함

🤖 Generated with [Claude Code](https://claude.com/claude-code)